### PR TITLE
修复设置页影片语言失效的问题。

### DIFF
--- a/app/src/main/java/com/yenaly/han1meviewer/Preferences.kt
+++ b/app/src/main/java/com/yenaly/han1meviewer/Preferences.kt
@@ -116,7 +116,7 @@ object Preferences {
         )?.toFloat() ?: HJzvdStd.DEF_LONG_PRESS_SPEED_TIMES
 
     val videoLanguage: String
-        get() = preferenceSp.getString(HomeSettingsFragment.VIDEO_LANGUAGE, "zh-CHT") ?: "zh-CHT"
+        get() = preferenceSp.getString(HomeSettingsFragment.VIDEO_LANGUAGE, "zhs") ?: "zht"
 
     val baseUrl: String
         get() = preferenceSp.getString(NetworkSettingsFragment.DOMAIN_NAME, HANIME_MAIN_BASE_URL)

--- a/app/src/main/java/com/yenaly/han1meviewer/ui/fragment/settings/HomeSettingsFragment.kt
+++ b/app/src/main/java/com/yenaly/han1meviewer/ui/fragment/settings/HomeSettingsFragment.kt
@@ -169,7 +169,7 @@ class HomeSettingsFragment : YenalySettingsFragment(R.xml.settings_home) {
                 getString(R.string.traditional_chinese),
                 getString(R.string.simplified_chinese)
             )
-            entryValues = arrayOf("zh-CHT", "zh-CHS")
+            entryValues = arrayOf("zht", "zhs")
             // 不能直接用 defaultValue 设置，没效果
             if (value == null) setValueIndex(0)
 


### PR DESCRIPTION
总有人问怎么切换字幕，实际网站提供的是压制好的视频源，字幕已经和视频压一起了，切换语言切换的是视频源。