### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Pull Request Check
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/misaka10032w/Han1meViewer/security/code-scanning/1](https://github.com/misaka10032w/Han1meViewer/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow. The best way is to add it at the root level of the workflow file, so it applies to all jobs unless overridden. Based on the workflow's steps, the minimal required permission is `contents: read`, which allows the workflow to check out code and upload artifacts, but does not allow write access to the repository. You should add the following block after the `name:` line and before the `on:` block in `.github/workflows/ci.yml`:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
