### PR TITLE
[Fix] 修复因并行下载任务拉到最左边导致的卡在启动画面的问题

### DIFF
--- a/app/src/main/java/com/yenaly/han1meviewer/worker/HanimeDownloadManagerV2.kt
+++ b/app/src/main/java/com/yenaly/han1meviewer/worker/HanimeDownloadManagerV2.kt
@@ -33,7 +33,7 @@ object HanimeDownloadManagerV2 {
     private const val TAG = "HanimeDownloadManager"
 
     const val MAX_CONCURRENT_DOWNLOAD_DEF = 2
-    var maxConcurrentDownloadCount = Preferences.downloadCountLimit
+    var maxConcurrentDownloadCount = 0
         set(value) {
             field = if (value > 0) value else Int.MAX_VALUE
             // 如果更新并发数，重新创建 semaphore
@@ -43,7 +43,12 @@ object HanimeDownloadManagerV2 {
     private val workManager = WorkManager.getInstance(applicationContext)
 
     // 信号量限制同时下载的任务数量
-    private var semaphore = Semaphore(maxConcurrentDownloadCount)
+    private var semaphore: Semaphore = Semaphore(1)
+
+    init {
+        // 用 Preferences 里的值初始化，保证 0 会被转换成 Int.MAX_VALUE
+        maxConcurrentDownloadCount = Preferences.downloadCountLimit
+    }
 
     // Channel 内部状态：保存正在下载任务与等待队列
     private val activeDownloads = linkedMapOf<String, HanimeDownloadWorker.Args>()


### PR DESCRIPTION
由于初始化顺序问题，
`var maxConcurrentDownloadCount = Preferences.downloadCountLimit
        set(value) {
            field = if (value > 0) value else Int.MAX_VALUE
            semaphore = Semaphore(field)
        }`
并没有走set，导致Semaphore被赋值为0触发
java.lang.IllegalArgumentException: Semaphore should have at least 1 permit, but had 0 