### PR TITLE
[Fixed] 修复动态配色选项在Android 12以下设备可见，导致误选，进而触发应用崩溃的问题 

### DIFF
--- a/app/src/main/java/com/yenaly/han1meviewer/ui/component/ChoiceDialog.kt
+++ b/app/src/main/java/com/yenaly/han1meviewer/ui/component/ChoiceDialog.kt
@@ -2,10 +2,14 @@ package com.yenaly.han1meviewer.ui.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -27,7 +31,12 @@ fun ChoiceDialog(
         onDismissRequest = onDismiss,
         title = { Text(title) },
         text = {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Column(
+                modifier = Modifier
+                    .heightIn(max = 420.dp)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
                 options.forEach { (label, value) ->
                     SettingChoiceItem(
                         title = label,

--- a/app/src/main/java/com/yenaly/han1meviewer/ui/screen/settings/HomeSettingsScreen.kt
+++ b/app/src/main/java/com/yenaly/han1meviewer/ui/screen/settings/HomeSettingsScreen.kt
@@ -147,7 +147,9 @@ fun HomeSettingsScreen(
     ChoiceDialog(
         visible = activeDialog == HomeSettingsChoiceDialog.ThemeColor,
         title = stringResource(R.string.theme_color),
-        options = ThemeColorPreset.entries.map { stringResource(it.displayNameRes) to it.key },
+        options = ThemeColorPreset.entries
+            .filter { state.dynamicColorEnabled || it != ThemeColorPreset.SYSTEM }
+            .map { stringResource(it.displayNameRes) to it.key },
         selectedValue = state.themeColorKey,
         onDismiss = { activeDialog = null },
         onSelect = {

--- a/app/src/main/java/com/yenaly/han1meviewer/ui/theme/Theme.kt
+++ b/app/src/main/java/com/yenaly/han1meviewer/ui/theme/Theme.kt
@@ -13,10 +13,14 @@ fun HanimeTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit,
 ) {
-    val preset = ThemeColorPreset.fromKey(Preferences.themeColor)
-    val colorScheme = when {
-        preset == ThemeColorPreset.SYSTEM && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ->
-            dynamicColorScheme(darkTheme)
+    val colorScheme = when (val preset = ThemeColorPreset.fromKey(Preferences.themeColor)) {
+        ThemeColorPreset.SYSTEM -> {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                dynamicColorScheme(darkTheme)
+            } else {
+                ThemeColorPreset.DEFAULT.colorScheme(darkTheme)
+            }
+        }
 
         else -> preset.colorScheme(darkTheme)
     }


### PR DESCRIPTION
Android 12以下设备不支持动态配色