### PR TITLE
[Improved] 增加标签、部分视频元数据的多语言，补齐日文翻译

### DIFF
--- a/app/src/main/assets/report_reason.json
+++ b/app/src/main/assets/report_reason.json
@@ -3,7 +3,8 @@
     "lang": {
       "zh-rCN": "煽动仇恨或恶意内容",
       "en": "Inciting hatred or malicious content",
-      "zh-rTW": "煽動仇恨或惡意內容"
+      "zh-rTW": "煽動仇恨或惡意內容",
+      "ja": "憎悪や悪意のある内容の扇動"
     },
     "reason_key": "煽動仇恨或惡意內容"
   },
@@ -11,7 +12,8 @@
     "lang": {
       "zh-rCN": "暴力或令人反感的内容",
       "en": "Violent or offensive content",
-      "zh-rTW": "暴力或令人反感的內容"
+      "zh-rTW": "暴力或令人反感的內容",
+      "ja": "暴力的または不快な内容"
     },
     "reason_key": "暴力或令人反感的內容"
   },
@@ -19,7 +21,8 @@
     "lang": {
       "zh-rCN": "广告内容或垃圾内容",
       "en": "Advertising content or spam",
-      "zh-rTW": "廣告內容或垃圾內容"
+      "zh-rTW": "廣告內容或垃圾內容",
+      "ja": "広告またはスパムの内容"
     },
     "reason_key": "廣告內容或垃圾內容"
   },
@@ -27,7 +30,8 @@
     "lang": {
       "zh-rCN": "其他检举理由",
       "en": "Other reporting reasons",
-      "zh-rTW": "其他檢舉理由"
+      "zh-rTW": "其他檢舉理由",
+      "ja": "その他の通報理由"
     },
     "reason_key": "其他檢舉理由"
   }

--- a/app/src/main/assets/search_options/duration.json
+++ b/app/src/main/assets/search_options/duration.json
@@ -3,7 +3,8 @@
     "lang": {
       "zh-rCN": "全部",
       "en": "All",
-      "zh-rTW": "全部"
+      "zh-rTW": "全部",
+      "ja": "すべて"
     },
     "search_key": null
   },
@@ -11,7 +12,8 @@
     "lang": {
       "zh-rCN": "1分钟以上",
       "en": "More than 1 minute",
-      "zh-rTW": "1分鐘以上"
+      "zh-rTW": "1分鐘以上",
+      "ja": "1分以上"
     },
     "search_key": "1 分鐘 +"
   },
@@ -19,7 +21,8 @@
     "lang": {
       "zh-rCN": "5分钟以上",
       "en": "More than 5 minute",
-      "zh-rTW": "5分鐘以上"
+      "zh-rTW": "5分鐘以上",
+      "ja": "5分以上"
     },
     "search_key": "5 分鐘 +"
   },
@@ -27,7 +30,8 @@
     "lang": {
       "zh-rCN": "10分钟以上",
       "en": "More than 10 minutes",
-      "zh-rTW": "10分鐘以上"
+      "zh-rTW": "10分鐘以上",
+      "ja": "10分以上"
     },
     "search_key": "10 分鐘 +"
   },
@@ -35,7 +39,8 @@
     "lang": {
       "zh-rCN": "20分钟以上",
       "en": "More than 20 minutes",
-      "zh-rTW": "20分鐘以上"
+      "zh-rTW": "20分鐘以上",
+      "ja": "20分以上"
     },
     "search_key": "20 分鐘 +"
   },
@@ -43,7 +48,8 @@
     "lang": {
       "zh-rCN": "30分钟以上",
       "en": "More than 30 minutes",
-      "zh-rTW": "30分鐘以上"
+      "zh-rTW": "30分鐘以上",
+      "ja": "30分以上"
     },
     "search_key": "30 分鐘 +"
   },
@@ -51,7 +57,8 @@
     "lang": {
       "zh-rCN": "60分钟以上",
       "en": "More than 60 minutes",
-      "zh-rTW": "60分鐘以上"
+      "zh-rTW": "60分鐘以上",
+      "ja": "60分以上"
     },
     "search_key": "60 分鐘 +"
   },
@@ -59,7 +66,8 @@
     "lang": {
       "zh-rCN": "0~10分钟",
       "en": "0~10 minutes",
-      "zh-rTW": "0~10分鐘"
+      "zh-rTW": "0~10分鐘",
+      "ja": "0〜10分"
     },
     "search_key": "0 - 10 分鐘"
   },
@@ -67,7 +75,8 @@
     "lang": {
       "zh-rCN": "0~20分钟",
       "en": "0~20 minutes",
-      "zh-rTW": "0~20分鐘以上"
+      "zh-rTW": "0~20分鐘以上",
+      "ja": "0〜20分"
     },
     "search_key": "0 - 20 分鐘"
   }

--- a/app/src/main/assets/search_options/genre.json
+++ b/app/src/main/assets/search_options/genre.json
@@ -3,7 +3,8 @@
     "lang": {
       "zh-rCN": "全部",
       "en": "All",
-      "zh-rTW": "全部"
+      "zh-rTW": "全部",
+      "ja": "すべて"
     },
     "search_key": "全部"
   },
@@ -11,7 +12,8 @@
     "lang": {
       "zh-rCN": "里番",
       "en": "Hentai",
-      "zh-rTW": "裏番"
+      "zh-rTW": "裏番",
+      "ja": "裏番"
     },
     "search_key": "裏番"
   },
@@ -19,7 +21,8 @@
     "lang": {
       "zh-rCN": "泡面番",
       "en": "Short Anime",
-      "zh-rTW": "泡麵番"
+      "zh-rTW": "泡麵番",
+      "ja": "ショートアニメ"
     },
     "search_key": "泡麵番"
   },
@@ -27,7 +30,8 @@
     "lang": {
       "zh-rCN": "Motion Anime",
       "en": "Motion Anime",
-      "zh-rTW": "Motion Anime"
+      "zh-rTW": "Motion Anime",
+      "ja": "モーションアニメ"
     },
     "search_key": "Motion Anime"
   },
@@ -35,7 +39,8 @@
     "lang": {
       "zh-rCN": "3D动画",
       "en": "3D Animation",
-      "zh-rTW": "3D動畫"
+      "zh-rTW": "3D動畫",
+      "ja": "3Dアニメ"
     },
     "search_key": "3DCG"
   },
@@ -43,7 +48,8 @@
     "lang": {
       "zh-rCN": "2.5D",
       "en": "2.5D",
-      "zh-rTW": "2.5D"
+      "zh-rTW": "2.5D",
+      "ja": "2.5D"
     },
     "search_key": "2.5D"
   },
@@ -51,7 +57,8 @@
     "lang": {
       "zh-rCN": "2D动画",
       "en": "2D Animation",
-      "zh-rTW": "2D動畫"
+      "zh-rTW": "2D動畫",
+      "ja": "2Dアニメ"
     },
     "search_key": "2D動畫"
   },
@@ -59,7 +66,8 @@
     "lang": {
       "zh-rCN": "AI生成",
       "en": "AI-Generated",
-      "zh-rTW": "AI生成"
+      "zh-rTW": "AI生成",
+      "ja": "AI生成"
     },
     "search_key": "AI生成"
   },
@@ -67,7 +75,8 @@
     "lang": {
       "zh-rCN": "MMD",
       "en": "MMD",
-      "zh-rTW": "MMD"
+      "zh-rTW": "MMD",
+      "ja": "MMD"
     },
     "search_key": "MMD"
   },
@@ -75,7 +84,8 @@
     "lang": {
       "zh-rCN": "Cosplay",
       "en": "Cosplay",
-      "zh-rTW": "Cosplay"
+      "zh-rTW": "Cosplay",
+      "ja": "コスプレ"
     },
     "search_key": "Cosplay"
   }

--- a/app/src/main/assets/search_options/release_date.json
+++ b/app/src/main/assets/search_options/release_date.json
@@ -3,7 +3,8 @@
     "lang": {
       "zh-rCN": "全部",
       "en": "All",
-      "zh-rTW": "全部"
+      "zh-rTW": "全部",
+      "ja": "すべて"
     },
     "search_key": null
   },
@@ -11,7 +12,8 @@
     "lang": {
       "zh-rCN": "过去24小时",
       "en": "Last 24 hours",
-      "zh-rTW": "過去24小時"
+      "zh-rTW": "過去24小時",
+      "ja": "過去24時間"
     },
     "search_key": "過去 24 小時"
   },
@@ -19,7 +21,8 @@
     "lang": {
       "zh-rCN": "过去2天",
       "en": "Last 2 days",
-      "zh-rTW": "過去2天"
+      "zh-rTW": "過去2天",
+      "ja": "過去2日"
     },
     "search_key": "過去 2 天"
   },
@@ -27,7 +30,8 @@
     "lang": {
       "zh-rCN": "过去1周",
       "en": "Last week",
-      "zh-rTW": "過去1週"
+      "zh-rTW": "過去1週",
+      "ja": "過去1週間"
     },
     "search_key": "過去 1 週"
   },
@@ -35,7 +39,8 @@
     "lang": {
       "zh-rCN": "过去1个月",
       "en": "Last month",
-      "zh-rTW": "過去1個月"
+      "zh-rTW": "過去1個月",
+      "ja": "過去1か月"
     },
     "search_key": "過去 1 個月"
   },
@@ -43,7 +48,8 @@
     "lang": {
       "zh-rCN": "过去3个月",
       "en": "Last 3 months",
-      "zh-rTW": "過去3個月"
+      "zh-rTW": "過去3個月",
+      "ja": "過去3か月"
     },
     "search_key": "過去 3 個月"
   },
@@ -51,7 +57,8 @@
     "lang": {
       "zh-rCN": "过去1年",
       "en": "Past year",
-      "zh-rTW": "過去1年"
+      "zh-rTW": "過去1年",
+      "ja": "過去1年"
     },
     "search_key": "過去 1 年"
   }

--- a/app/src/main/assets/search_options/sort_option.json
+++ b/app/src/main/assets/search_options/sort_option.json
@@ -3,7 +3,8 @@
     "lang": {
       "zh-rCN": "最新上市",
       "en": "New Arrival",
-      "zh-rTW": "最新上市"
+      "zh-rTW": "最新上市",
+      "ja": "新着発売"
     },
     "search_key": "最新上市"
   },
@@ -11,7 +12,8 @@
     "lang": {
       "zh-rCN": "最新上傳",
       "en": "New Upload",
-      "zh-rTW": "最新上傳"
+      "zh-rTW": "最新上傳",
+      "ja": "新着アップロード"
     },
     "search_key": "最新上傳"
   },
@@ -19,7 +21,8 @@
     "lang": {
       "zh-rCN": "本日排行",
       "en": "Daily Ranking",
-      "zh-rTW": "本日排行"
+      "zh-rTW": "本日排行",
+      "ja": "本日ランキング"
     },
     "search_key": "本日排行"
   },
@@ -27,7 +30,8 @@
     "lang": {
       "zh-rCN": "本週排行",
       "en": "Weekly Ranking",
-      "zh-rTW": "本週排行"
+      "zh-rTW": "本週排行",
+      "ja": "週間ランキング"
     },
     "search_key": "本週排行"
   },
@@ -35,7 +39,8 @@
     "lang": {
       "zh-rCN": "本月排行",
       "en": "Monthly Ranking",
-      "zh-rTW": "本月排行"
+      "zh-rTW": "本月排行",
+      "ja": "月間ランキング"
     },
     "search_key": "本月排行"
   },
@@ -43,7 +48,8 @@
     "lang": {
       "zh-rCN": "观看次数",
       "en": "View Count",
-      "zh-rTW": "觀看次數"
+      "zh-rTW": "觀看次數",
+      "ja": "視聴回数"
     },
     "search_key": "觀看次數"
   },
@@ -51,7 +57,8 @@
     "lang": {
       "zh-rCN": "点赞比例",
       "en": "Like Ratio",
-      "zh-rTW": "讚好比例"
+      "zh-rTW": "讚好比例",
+      "ja": "高評価率"
     },
     "search_key": "讚好比例"
   },
@@ -59,7 +66,8 @@
     "lang": {
       "zh-rCN": "他们在看",
       "en": "Trending",
-      "zh-rTW": "他們在看"
+      "zh-rTW": "他們在看",
+      "ja": "トレンド"
     },
     "search_key": "他們在看"
   },
@@ -67,7 +75,8 @@
     "lang": {
       "zh-rCN": "时长最长",
       "en": "Longest duration",
-      "zh-rTW": "時長最長"
+      "zh-rTW": "時長最長",
+      "ja": "再生時間が長い"
     },
     "search_key": "時長最長"
   }

--- a/app/src/main/assets/search_options/tags.json
+++ b/app/src/main/assets/search_options/tags.json
@@ -34,6 +34,30 @@
     },
     {
       "lang": {
+        "zh-rCN": "同人作品",
+        "en": "Fan Video",
+        "zh-rTW": "同人作品"
+      },
+      "search_key": "同人作品"
+    },
+    {
+      "lang": {
+        "zh-rCN": "断面图",
+        "en": "Cross-section",
+        "zh-rTW": "斷面圖"
+      },
+      "search_key": "斷面圖"
+    },
+    {
+      "lang": {
+        "zh-rCN": "ASMR",
+        "en": "ASMR",
+        "zh-rTW": "ASMR"
+      },
+      "search_key": "ASMR"
+    },
+    {
+      "lang": {
         "zh-rCN": "1080P",
         "en": "1080P",
         "zh-rTW": "1080P"
@@ -47,70 +71,6 @@
         "zh-rTW": "60FPS"
       },
       "search_key": "60FPS"
-    },
-    {
-      "lang": {
-        "zh-rCN": "ASMR",
-        "en": "ASMR",
-        "zh-rTW": "ASMR"
-      },
-      "search_key": "ASMR"
-    },
-    {
-      "lang": {
-        "zh-rCN": "断面图",
-        "en": "Cross-section",
-        "zh-rTW": "斷面圖"
-      },
-      "search_key": "斷面圖"
-    },
-    {
-      "lang": {
-        "zh-rCN": "雷火剑",
-        "en": "Raika Ken",
-        "zh-rTW": "雷火劍"
-      },
-      "search_key": "雷火劍"
-    },
-    {
-      "lang": {
-        "zh-rCN": "武田弘光",
-        "en": "Takeda Hiromitsu",
-        "zh-rTW": "武田弘光"
-      },
-      "search_key": "武田弘光"
-    },
-    {
-      "lang": {
-        "zh-rCN": "爱上陆",
-        "en": "Aiue Oka",
-        "zh-rTW": "愛上陸"
-      },
-      "search_key": "愛上陸"
-    },
-    {
-      "lang": {
-        "zh-rCN": "荒木英树",
-        "en": "Hideki Araki",
-        "zh-rTW": "荒木英樹"
-      },
-      "search_key": "荒木英樹"
-    },
-    {
-      "lang": {
-        "zh-rCN": "辰美",
-        "en": "Tatsumi",
-        "zh-rTW": "辰美"
-      },
-      "search_key": "辰美"
-    },
-    {
-      "lang": {
-        "zh-rCN": "梅津泰臣",
-        "en": "Yasuomi Umetsu",
-        "zh-rTW": "梅津泰臣"
-      },
-      "search_key": "梅津泰臣"
     }
   ],
   "character_relationships": [
@@ -446,6 +406,14 @@
     },
     {
       "lang": {
+        "zh-rCN": "Furry",
+        "en": "Furry",
+        "zh-rTW": "Furry"
+      },
+      "search_key": "福瑞"
+    },
+    {
+      "lang": {
         "zh-rCN": "乳牛",
         "en": "Cow Girl",
         "zh-rTW": "乳牛"
@@ -584,6 +552,14 @@
     },
     {
       "lang": {
+        "zh-rCN": "丸子头",
+        "en": "Hair bun",
+        "zh-rTW": "丸子頭"
+      },
+      "search_key": "丸子頭"
+    },
+    {
+      "lang": {
         "zh-rCN": "巨乳",
         "en": "Big Breasts",
         "zh-rTW": "巨乳"
@@ -712,6 +688,14 @@
     },
     {
       "lang": {
+        "zh-rCN": "穿衣",
+        "en": "Clothed",
+        "zh-rTW": "著衣"
+      },
+      "search_key": "著衣"
+    },
+    {
+      "lang": {
         "zh-rCN": "水手服",
         "en": "Sailor Suit",
         "zh-rTW": "水手服"
@@ -804,7 +788,7 @@
         "en": "Hot Pants",
         "zh-rTW": "熱褲"
       },
-      "search_key": "��褲"
+      "search_key": "熱褲"
     },
     {
       "lang": {
@@ -848,6 +832,14 @@
     },
     {
       "lang": {
+        "zh-rCN": "睡衣",
+        "en": "Nightwear",
+        "zh-rTW": "睡衣"
+      },
+      "search_key": "睡衣"
+    },
+    {
+      "lang": {
         "zh-rCN": "婚纱",
         "en": "Bride",
         "zh-rTW": "婚紗"
@@ -876,7 +868,7 @@
         "en": "Gothic Lolita",
         "zh-rTW": "哥德蘿莉塔"
       },
-      "search_key": "哥德蘿莉塔"
+      "search_key": "哥德"
     },
     {
       "lang": {
@@ -1132,43 +1124,19 @@
     },
     {
       "lang": {
+        "zh-rCN": "十指紧扣",
+        "en": "Interlocked fingers",
+        "zh-rTW": "十指緊扣"
+      },
+      "search_key": "十指緊扣"
+    },
+    {
+      "lang": {
         "zh-rCN": "开大车",
         "en": "Older Woman Younger Man",
         "zh-rTW": "開大車"
       },
       "search_key": "開大車"
-    },
-    {
-      "lang": {
-        "zh-rCN": "校园",
-        "en": "School Setting",
-        "zh-rTW": "校園"
-      },
-      "search_key": "校園"
-    },
-    {
-      "lang": {
-        "zh-rCN": "教室",
-        "en": "Classroom",
-        "zh-rTW": "教室"
-      },
-      "search_key": "教室"
-    },
-    {
-      "lang": {
-        "zh-rCN": "公众场合",
-        "en": "Public Place",
-        "zh-rTW": "公眾場合"
-      },
-      "search_key": "公眾場合"
-    },
-    {
-      "lang": {
-        "zh-rCN": "公共厕所",
-        "en": "Public Restroom",
-        "zh-rTW": "公共廁所"
-      },
-      "search_key": "公共廁所"
     },
     {
       "lang": {
@@ -1332,30 +1300,6 @@
     },
     {
       "lang": {
-        "zh-rCN": "扯头发",
-        "en": "Hair Pulling",
-        "zh-rTW": "扯頭髮"
-      },
-      "search_key": "扯頭髮"
-    },
-    {
-      "lang": {
-        "zh-rCN": "打屁股",
-        "en": "Spanking",
-        "zh-rTW": "打屁股"
-      },
-      "search_key": "打屁股"
-    },
-    {
-      "lang": {
-        "zh-rCN": "肉棒打脸",
-        "en": "Cock Slap",
-        "zh-rTW": "肉棒打臉"
-    },
-    "search_key": "肉棒打臉"
-    },
-    {
-      "lang": {
         "zh-rCN": "性暴力",
         "en": "Sexual Violence",
         "zh-rTW": "性暴力"
@@ -1377,6 +1321,14 @@
         "zh-rTW": "女王樣"
       },
       "search_key": "女王樣"
+    },
+    {
+      "lang": {
+        "zh-rCN": "榨精",
+        "en": "Semen collection",
+        "zh-rTW": "榨精"
+      },
+      "search_key": "榨精"
     },
     {
       "lang": {
@@ -1527,7 +1479,7 @@
     {
       "lang": {
         "zh-rCN": "乳交",
-        "en": "Tittyfuck",
+        "en": "Titty fuck",
         "zh-rTW": "乳交"
       },
       "search_key": "乳交"
@@ -1603,6 +1555,14 @@
         "zh-rTW": "口交"
       },
       "search_key": "口交"
+    },
+    {
+      "lang": {
+        "zh-rCN": "跪舔",
+        "en": "Grovel",
+        "zh-rTW": "跪舔"
+      },
+      "search_key": "跪舔"
     },
     {
       "lang": {
@@ -1694,7 +1654,15 @@
     },
     {
       "lang": {
-        "zh-rCN": "內射",
+        "zh-rCN": "舔脚",
+        "en": "Feet Licking",
+        "zh-rTW": "舔腳"
+      },
+      "search_key": "舔腳"
+    },
+    {
+      "lang": {
+        "zh-rCN": "内射",
         "en": "Internal Ejaculation",
         "zh-rTW": "內射"
       },
@@ -1790,11 +1758,11 @@
     },
     {
       "lang": {
-        "zh-rCN": "车震",
-        "en": "Car Sex",
-        "zh-rTW": "車震"
+        "zh-rCN": "一字马",
+        "en": "Do the splits",
+        "zh-rTW": "一字馬"
       },
-      "search_key": "車震"
+      "search_key": "一字馬"
     },
     {
       "lang": {
@@ -1854,11 +1822,35 @@
     },
     {
       "lang": {
-        "zh-rCN": "着衣",
-        "en": "Clothed Sex",
-        "zh-rTW": "著衣"
+        "zh-rCN": "扯头发",
+        "en": "Hair pulling",
+        "zh-rTW": "扯頭髮"
       },
-      "search_key": "著衣"
+      "search_key": "扯頭髮"
+    },
+    {
+      "lang": {
+        "zh-rCN": "掐脖子",
+        "en": "Choking",
+        "zh-rTW": "掐脖子"
+      },
+      "search_key": "掐脖子"
+    },
+    {
+      "lang": {
+        "zh-rCN": "打屁股",
+        "en": "Spanking",
+        "zh-rTW": "打屁股"
+      },
+      "search_key": "打屁股"
+    },
+    {
+      "lang": {
+        "zh-rCN": "肉棒打脸",
+        "en": "Cock Slap",
+        "zh-rTW": "肉棒打臉"
+      },
+      "search_key": "肉棒打臉"
     },
     {
       "lang": {
@@ -1867,6 +1859,14 @@
         "zh-rTW": "陰道外翻"
       },
       "search_key": "陰道外翻"
+    },
+    {
+      "lang": {
+        "zh-rCN": "男乳首责",
+        "en": "Male tit torture",
+        "zh-rTW": "男乳首責"
+      },
+      "search_key": "男乳首責"
     },
     {
       "lang": {

--- a/app/src/main/assets/search_options/tags.json
+++ b/app/src/main/assets/search_options/tags.json
@@ -4,72 +4,90 @@
       "lang": {
         "zh-rCN": "无码",
         "en": "Uncensored",
-        "zh-rTW": "無碼"
+        "zh-rTW": "無碼",
+        "ja": "無修正"
       },
+      "name": "无码",
       "search_key": "無碼"
     },
     {
       "lang": {
         "zh-rCN": "AI解码",
         "en": "AI Decoded",
-        "zh-rTW": "AI解碼"
+        "zh-rTW": "AI解碼",
+        "ja": "AIデコード"
       },
+      "name": "AI解码",
       "search_key": "AI解碼"
     },
     {
       "lang": {
         "zh-rCN": "中文字幕",
         "en": "Chinese Subtitle",
-        "zh-rTW": "中文字幕"
+        "zh-rTW": "中文字幕",
+        "ja": "中国語字幕"
       },
+      "name": "中文字幕",
       "search_key": "中文字幕"
     },
     {
       "lang": {
         "zh-rCN": "中文配音",
         "en": "Chinese dubbing",
-        "zh-rTW": "中文配音"
+        "zh-rTW": "中文配音",
+        "ja": "中国語吹き替え"
       },
+      "name": "中文配音",
       "search_key": "中文配音"
     },
     {
       "lang": {
         "zh-rCN": "同人作品",
         "en": "Fan Video",
-        "zh-rTW": "同人作品"
+        "zh-rTW": "同人作品",
+        "ja": "同人作品"
       },
+      "name": "同人作品",
       "search_key": "同人作品"
     },
     {
       "lang": {
         "zh-rCN": "断面图",
         "en": "Cross-section",
-        "zh-rTW": "斷面圖"
+        "zh-rTW": "斷面圖",
+        "ja": "断面図"
       },
+      "name": "断面图",
       "search_key": "斷面圖"
     },
     {
       "lang": {
         "zh-rCN": "ASMR",
         "en": "ASMR",
-        "zh-rTW": "ASMR"
+        "zh-rTW": "ASMR",
+        "ja": "ASMR"
       },
+      "name": "ASMR",
       "search_key": "ASMR"
     },
     {
       "lang": {
         "zh-rCN": "1080P",
         "en": "1080P",
-        "zh-rTW": "1080P"
+        "zh-rTW": "1080P",
+        "ja": "1080p"
       },
+      "name": "1080p",
       "search_key": "1080p"
     },
     {
       "lang": {
         "zh-rCN": "60FPS",
         "en": "60FPS",
-        "zh-rTW": "60FPS"
+        "zh-rTW": "60FPS",
+        "ja": "60FPS"
       },
+      "name": "60FPS",
       "search_key": "60FPS"
     }
   ],
@@ -78,72 +96,90 @@
       "lang": {
         "zh-rCN": "近亲",
         "en": "Incest",
-        "zh-rTW": "近親"
+        "zh-rTW": "近親",
+        "ja": "近親"
       },
+      "name": "近亲",
       "search_key": "近親"
     },
     {
       "lang": {
         "zh-rCN": "姐",
         "en": "Elder Sister",
-        "zh-rTW": "姐"
+        "zh-rTW": "姐",
+        "ja": "姉"
       },
+      "name": "姐",
       "search_key": "姐"
     },
     {
       "lang": {
         "zh-rCN": "妹",
         "en": "Younger Sister",
-        "zh-rTW": "妹"
+        "zh-rTW": "妹",
+        "ja": "妹"
       },
+      "name": "妹",
       "search_key": "妹"
     },
     {
       "lang": {
         "zh-rCN": "母",
         "en": "Mother",
-        "zh-rTW": "母"
+        "zh-rTW": "母",
+        "ja": "母"
       },
+      "name": "母",
       "search_key": "母"
     },
     {
       "lang": {
         "zh-rCN": "女儿",
         "en": "Daughter",
-        "zh-rTW": "女兒"
+        "zh-rTW": "女兒",
+        "ja": "娘"
       },
+      "name": "女儿",
       "search_key": "女兒"
     },
     {
       "lang": {
         "zh-rCN": "师生",
         "en": "Teacher Student",
-        "zh-rTW": "師生"
+        "zh-rTW": "師生",
+        "ja": "教師と生徒"
       },
+      "name": "师生",
       "search_key": "師生"
     },
     {
       "lang": {
         "zh-rCN": "情侣",
         "en": "Couple",
-        "zh-rTW": "情侶"
+        "zh-rTW": "情侶",
+        "ja": "カップル"
       },
+      "name": "情侣",
       "search_key": "情侶"
     },
     {
       "lang": {
         "zh-rCN": "青梅竹马",
         "en": "Childhood Friend",
-        "zh-rTW": "青梅竹馬"
+        "zh-rTW": "青梅竹馬",
+        "ja": "幼なじみ"
       },
+      "name": "青梅竹马",
       "search_key": "青梅竹馬"
     },
     {
       "lang": {
         "zh-rCN": "同事",
         "en": "Colleague",
-        "zh-rTW": "同事"
+        "zh-rTW": "同事",
+        "ja": "同僚"
       },
+      "name": "同事",
       "search_key": "同事"
     }
   ],
@@ -152,376 +188,470 @@
       "lang": {
         "zh-rCN": "JK",
         "en": "JK",
-        "zh-rTW": "JK"
+        "zh-rTW": "JK",
+        "ja": "JK"
       },
+      "name": "JK",
       "search_key": "JK"
     },
     {
       "lang": {
         "zh-rCN": "处女",
         "en": "Virgin",
-        "zh-rTW": "處女"
+        "zh-rTW": "處女",
+        "ja": "処女"
       },
+      "name": "处女",
       "search_key": "處女"
     },
     {
       "lang": {
         "zh-rCN": "御姐",
         "en": "Older Sister",
-        "zh-rTW": "御姐"
+        "zh-rTW": "御姐",
+        "ja": "お姉さん"
       },
+      "name": "御姐",
       "search_key": "御姐"
     },
     {
       "lang": {
         "zh-rCN": "熟女",
         "en": "MILF",
-        "zh-rTW": "熟女"
+        "zh-rTW": "熟女",
+        "ja": "熟女"
       },
+      "name": "熟女",
       "search_key": "熟女"
     },
     {
       "lang": {
         "zh-rCN": "人妻",
         "en": "Married Woman",
-        "zh-rTW": "人妻"
+        "zh-rTW": "人妻",
+        "ja": "人妻"
       },
+      "name": "人妻",
       "search_key": "人妻"
     },
     {
       "lang": {
         "zh-rCN": "女教师",
         "en": "Female Teacher",
-        "zh-rTW": "女教師"
+        "zh-rTW": "女教師",
+        "ja": "女教師"
       },
+      "name": "女教师",
       "search_key": "女教師"
     },
     {
       "lang": {
         "zh-rCN": "男教师",
         "en": "Male Teacher",
-        "zh-rTW": "男教師"
+        "zh-rTW": "男教師",
+        "ja": "男教師"
       },
+      "name": "男教师",
       "search_key": "男教師"
     },
     {
       "lang": {
         "zh-rCN": "女医生",
         "en": "Female Doctor",
-        "zh-rTW": "女醫生"
+        "zh-rTW": "女醫生",
+        "ja": "女医"
       },
+      "name": "女医生",
       "search_key": "女醫生"
     },
     {
       "lang": {
         "zh-rCN": "女病人",
         "en": "Female Patient",
-        "zh-rTW": "女病人"
+        "zh-rTW": "女病人",
+        "ja": "女性患者"
       },
+      "name": "女病人",
       "search_key": "女病人"
     },
     {
       "lang": {
         "zh-rCN": "护士",
         "en": "Nurse",
-        "zh-rTW": "護士"
+        "zh-rTW": "護士",
+        "ja": "看護師"
       },
+      "name": "护士",
       "search_key": "護士"
     },
     {
       "lang": {
         "zh-rCN": "OL",
         "en": "Office Lady",
-        "zh-rTW": "OL"
+        "zh-rTW": "OL",
+        "ja": "OL"
       },
+      "name": "OL",
       "search_key": "OL"
     },
     {
       "lang": {
         "zh-rCN": "女警",
         "en": "Policewoman",
-        "zh-rTW": "女警"
+        "zh-rTW": "女警",
+        "ja": "婦警"
       },
+      "name": "女警",
       "search_key": "女警"
     },
     {
       "lang": {
         "zh-rCN": "大小姐",
         "en": "Young Lady",
-        "zh-rTW": "大小姐"
+        "zh-rTW": "大小姐",
+        "ja": "お嬢様"
       },
+      "name": "大小姐",
       "search_key": "大小姐"
     },
     {
       "lang": {
         "zh-rCN": "偶像",
         "en": "Idol",
-        "zh-rTW": "偶像"
+        "zh-rTW": "偶像",
+        "ja": "アイドル"
       },
+      "name": "偶像",
       "search_key": "偶像"
     },
     {
       "lang": {
         "zh-rCN": "女仆",
         "en": "Maid",
-        "zh-rTW": "女僕"
+        "zh-rTW": "女僕",
+        "ja": "メイド"
       },
+      "name": "女仆",
       "search_key": "女僕"
     },
     {
       "lang": {
         "zh-rCN": "巫女",
         "en": "Shrine Maiden",
-        "zh-rTW": "巫女"
+        "zh-rTW": "巫女",
+        "ja": "巫女"
       },
+      "name": "巫女",
       "search_key": "巫女"
     },
     {
       "lang": {
         "zh-rCN": "魔女",
         "en": "Witch",
-        "zh-rTW": "魔女"
+        "zh-rTW": "魔女",
+        "ja": "魔女"
       },
+      "name": "魔女",
       "search_key": "魔女"
     },
     {
       "lang": {
         "zh-rCN": "修女",
         "en": "Nun",
-        "zh-rTW": "修女"
+        "zh-rTW": "修女",
+        "ja": "シスター"
       },
+      "name": "修女",
       "search_key": "修女"
     },
     {
       "lang": {
         "zh-rCN": "风俗娘",
         "en": "Sex Worker",
-        "zh-rTW": "風俗娘"
+        "zh-rTW": "風俗娘",
+        "ja": "風俗嬢"
       },
+      "name": "风俗娘",
       "search_key": "風俗娘"
     },
     {
       "lang": {
         "zh-rCN": "公主",
         "en": "Princess",
-        "zh-rTW": "公主"
+        "zh-rTW": "公主",
+        "ja": "姫"
       },
+      "name": "公主",
       "search_key": "公主"
     },
     {
       "lang": {
         "zh-rCN": "女忍者",
         "en": "Kunoichi",
-        "zh-rTW": "女忍者"
+        "zh-rTW": "女忍者",
+        "ja": "女忍者"
       },
+      "name": "女忍者",
       "search_key": "女忍者"
     },
     {
       "lang": {
         "zh-rCN": "女战士",
         "en": "Female Warrior",
-        "zh-rTW": "女戰士"
+        "zh-rTW": "女戰士",
+        "ja": "女戦士"
       },
+      "name": "女战士",
       "search_key": "女戰士"
     },
     {
       "lang": {
         "zh-rCN": "女骑士",
         "en": "Female Knight",
-        "zh-rTW": "女騎士"
+        "zh-rTW": "女騎士",
+        "ja": "女騎士"
       },
+      "name": "女骑士",
       "search_key": "女騎士"
     },
     {
       "lang": {
         "zh-rCN": "魔法少女",
         "en": "Magical Girl",
-        "zh-rTW": "魔法少女"
+        "zh-rTW": "魔法少女",
+        "ja": "魔法少女"
       },
+      "name": "魔法少女",
       "search_key": "魔法少女"
     },
     {
       "lang": {
         "zh-rCN": "异种族",
         "en": "Different Species",
-        "zh-rTW": "異種族"
+        "zh-rTW": "異種族",
+        "ja": "異種族"
       },
+      "name": "异种族",
       "search_key": "異種族"
     },
     {
       "lang": {
         "zh-rCN": "天使",
         "en": "Angel",
-        "zh-rTW": "天使"
+        "zh-rTW": "天使",
+        "ja": "天使"
       },
+      "name": "天使",
       "search_key": "天使"
     },
     {
       "lang": {
         "zh-rCN": "妖精",
         "en": "Fairy",
-        "zh-rTW": "妖精"
+        "zh-rTW": "妖精",
+        "ja": "妖精"
       },
+      "name": "妖精",
       "search_key": "妖精"
     },
     {
       "lang": {
         "zh-rCN": "魔物娘",
         "en": "Monster Girl",
-        "zh-rTW": "魔物娘"
+        "zh-rTW": "魔物娘",
+        "ja": "魔物娘"
       },
+      "name": "魔物娘",
       "search_key": "魔物娘"
     },
     {
       "lang": {
         "zh-rCN": "魅魔",
         "en": "Succubus",
-        "zh-rTW": "魅魔"
+        "zh-rTW": "魅魔",
+        "ja": "サキュバス"
       },
+      "name": "魅魔",
       "search_key": "魅魔"
     },
     {
       "lang": {
         "zh-rCN": "吸血鬼",
         "en": "Vampire",
-        "zh-rTW": "吸血鬼"
+        "zh-rTW": "吸血鬼",
+        "ja": "吸血鬼"
       },
+      "name": "吸血鬼",
       "search_key": "吸血鬼"
     },
     {
       "lang": {
         "zh-rCN": "女鬼",
         "en": "Female Ghost",
-        "zh-rTW": "女鬼"
+        "zh-rTW": "女鬼",
+        "ja": "女幽霊"
       },
+      "name": "女鬼",
       "search_key": "女鬼"
     },
     {
       "lang": {
         "zh-rCN": "兽娘",
         "en": "Kemonomimi",
-        "zh-rTW": "獸娘"
+        "zh-rTW": "獸娘",
+        "ja": "獣娘"
       },
+      "name": "兽娘",
       "search_key": "獸娘"
     },
     {
       "lang": {
         "zh-rCN": "Furry",
         "en": "Furry",
-        "zh-rTW": "Furry"
+        "zh-rTW": "Furry",
+        "ja": "ファーリー"
       },
+      "name": "福瑞",
       "search_key": "福瑞"
     },
     {
       "lang": {
         "zh-rCN": "乳牛",
         "en": "Cow Girl",
-        "zh-rTW": "乳牛"
+        "zh-rTW": "乳牛",
+        "ja": "乳牛"
       },
+      "name": "乳牛",
       "search_key": "乳牛"
     },
     {
       "lang": {
         "zh-rCN": "机械娘",
         "en": "Android Girl",
-        "zh-rTW": "機械娘"
+        "zh-rTW": "機械娘",
+        "ja": "メカ娘"
       },
+      "name": "机械娘",
       "search_key": "機械娘"
     },
     {
       "lang": {
         "zh-rCN": "碧池",
         "en": "Bitch",
-        "zh-rTW": "碧池"
+        "zh-rTW": "碧池",
+        "ja": "ビッチ"
       },
+      "name": "碧池",
       "search_key": "碧池"
     },
     {
       "lang": {
         "zh-rCN": "痴女",
         "en": "Nymphomaniac",
-        "zh-rTW": "痴女"
+        "zh-rTW": "痴女",
+        "ja": "痴女"
       },
+      "name": "痴女",
       "search_key": "痴女"
     },
     {
       "lang": {
         "zh-rCN": "雌小鬼",
         "en": "Cheeky Girl",
-        "zh-rTW": "雌小鬼"
+        "zh-rTW": "雌小鬼",
+        "ja": "メスガキ"
       },
+      "name": "雌小鬼",
       "search_key": "雌小鬼"
     },
     {
       "lang": {
         "zh-rCN": "不良少女",
         "en": "Delinquent Girl",
-        "zh-rTW": "不良少女"
+        "zh-rTW": "不良少女",
+        "ja": "不良少女"
       },
+      "name": "不良少女",
       "search_key": "不良少女"
     },
     {
       "lang": {
         "zh-rCN": "傲娇",
         "en": "Tsundere",
-        "zh-rTW": "傲嬌"
+        "zh-rTW": "傲嬌",
+        "ja": "ツンデレ"
       },
+      "name": "傲娇",
       "search_key": "傲嬌"
     },
     {
       "lang": {
         "zh-rCN": "病娇",
         "en": "Yandere",
-        "zh-rTW": "病嬌"
+        "zh-rTW": "病嬌",
+        "ja": "ヤンデレ"
       },
+      "name": "病娇",
       "search_key": "病嬌"
     },
     {
       "lang": {
         "zh-rCN": "无口",
         "en": "Quiet",
-        "zh-rTW": "無口"
+        "zh-rTW": "無口",
+        "ja": "無口"
       },
+      "name": "无口",
       "search_key": "無口"
     },
     {
       "lang": {
         "zh-rCN": "无表情",
         "en": "Expressionless",
-        "zh-rTW": "無表情"
+        "zh-rTW": "無表情",
+        "ja": "無表情"
       },
+      "name": "无表情",
       "search_key": "無表情"
     },
     {
       "lang": {
         "zh-rCN": "眼神死",
         "en": "Dead Eyes",
-        "zh-rTW": "眼神死"
+        "zh-rTW": "眼神死",
+        "ja": "死んだ目"
       },
+      "name": "眼神死",
       "search_key": "眼神死"
     },
     {
       "lang": {
         "zh-rCN": "正太",
         "en": "Shota",
-        "zh-rTW": "正太"
+        "zh-rTW": "正太",
+        "ja": "ショタ"
       },
+      "name": "正太",
       "search_key": "正太"
     },
     {
       "lang": {
         "zh-rCN": "伪娘",
         "en": "Crossdresser",
-        "zh-rTW": "偽娘"
+        "zh-rTW": "偽娘",
+        "ja": "男の娘"
       },
+      "name": "伪娘",
       "search_key": "偽娘"
     },
     {
       "lang": {
         "zh-rCN": "扶他",
         "en": "Futanari",
-        "zh-rTW": "扶他"
+        "zh-rTW": "扶他",
+        "ja": "ふたなり"
       },
+      "name": "扶他",
       "search_key": "扶他"
     }
   ],
@@ -530,376 +660,470 @@
       "lang": {
         "zh-rCN": "短发",
         "en": "Short Hair",
-        "zh-rTW": "短髮"
+        "zh-rTW": "短髮",
+        "ja": "ショートヘア"
       },
+      "name": "短发",
       "search_key": "短髮"
     },
     {
       "lang": {
         "zh-rCN": "马尾",
         "en": "Ponytail",
-        "zh-rTW": "馬尾"
+        "zh-rTW": "馬尾",
+        "ja": "ポニーテール"
       },
+      "name": "马尾",
       "search_key": "馬尾"
     },
     {
       "lang": {
         "zh-rCN": "双马尾",
         "en": "Twin Tail",
-        "zh-rTW": "雙馬尾"
+        "zh-rTW": "雙馬尾",
+        "ja": "ツインテール"
       },
+      "name": "双马尾",
       "search_key": "雙馬尾"
     },
     {
       "lang": {
         "zh-rCN": "丸子头",
         "en": "Hair bun",
-        "zh-rTW": "丸子頭"
+        "zh-rTW": "丸子頭",
+        "ja": "お団子ヘア"
       },
+      "name": "丸子头",
       "search_key": "丸子頭"
     },
     {
       "lang": {
         "zh-rCN": "巨乳",
         "en": "Big Breasts",
-        "zh-rTW": "巨乳"
+        "zh-rTW": "巨乳",
+        "ja": "巨乳"
       },
+      "name": "巨乳",
       "search_key": "巨乳"
     },
     {
       "lang": {
         "zh-rCN": "乳环",
         "en": "Nipple Ring",
-        "zh-rTW": "乳環"
+        "zh-rTW": "乳環",
+        "ja": "ニップルピアス"
       },
+      "name": "乳环",
       "search_key": "乳環"
     },
     {
       "lang": {
         "zh-rCN": "舌环",
         "en": "Tongue Ring",
-        "zh-rTW": "舌環"
+        "zh-rTW": "舌環",
+        "ja": "舌ピアス"
       },
+      "name": "舌环",
       "search_key": "舌環"
     },
     {
       "lang": {
         "zh-rCN": "贫乳",
         "en": "Small Breasts",
-        "zh-rTW": "貧乳"
+        "zh-rTW": "貧乳",
+        "ja": "貧乳"
       },
+      "name": "贫乳",
       "search_key": "貧乳"
     },
     {
       "lang": {
         "zh-rCN": "黑皮肤",
         "en": "Dark Skin",
-        "zh-rTW": "黑皮膚"
+        "zh-rTW": "黑皮膚",
+        "ja": "褐色肌"
       },
+      "name": "黑皮肤",
       "search_key": "黑皮膚"
     },
     {
       "lang": {
         "zh-rCN": "晒痕",
         "en": "Tanlines",
-        "zh-rTW": "曬痕"
+        "zh-rTW": "曬痕",
+        "ja": "日焼け跡"
       },
+      "name": "晒痕",
       "search_key": "曬痕"
     },
     {
       "lang": {
         "zh-rCN": "眼镜娘",
         "en": "Glasses",
-        "zh-rTW": "眼鏡娘"
+        "zh-rTW": "眼鏡娘",
+        "ja": "眼鏡っ娘"
       },
+      "name": "眼镜娘",
       "search_key": "眼鏡娘"
     },
     {
       "lang": {
         "zh-rCN": "兽耳",
         "en": "Animal Ears",
-        "zh-rTW": "獸耳"
+        "zh-rTW": "獸耳",
+        "ja": "獣耳"
       },
+      "name": "兽耳",
       "search_key": "獸耳"
     },
     {
       "lang": {
         "zh-rCN": "尖耳朵",
         "en": "Pointed Ears",
-        "zh-rTW": "尖耳朵"
+        "zh-rTW": "尖耳朵",
+        "ja": "尖り耳"
       },
+      "name": "尖耳朵",
       "search_key": "尖耳朵"
     },
     {
       "lang": {
         "zh-rCN": "异色瞳",
         "en": "Heterochromia",
-        "zh-rTW": "異色瞳"
+        "zh-rTW": "異色瞳",
+        "ja": "オッドアイ"
       },
+      "name": "异色瞳",
       "search_key": "異色瞳"
     },
     {
       "lang": {
         "zh-rCN": "美人痣",
         "en": "Beauty Mark",
-        "zh-rTW": "美人痣"
+        "zh-rTW": "美人痣",
+        "ja": "ほくろ"
       },
+      "name": "美人痣",
       "search_key": "美人痣"
     },
     {
       "lang": {
         "zh-rCN": "肌肉女",
         "en": "Muscle",
-        "zh-rTW": "肌肉女"
+        "zh-rTW": "肌肉女",
+        "ja": "筋肉娘"
       },
+      "name": "肌肉女",
       "search_key": "肌肉女"
     },
     {
       "lang": {
         "zh-rCN": "白虎",
         "en": "Virgin",
-        "zh-rTW": "白虎"
+        "zh-rTW": "白虎",
+        "ja": "パイパン"
       },
+      "name": "白虎",
       "search_key": "白虎"
     },
     {
       "lang": {
         "zh-rCN": "阴毛",
         "en": "Pubic Stubble",
-        "zh-rTW": "陰毛"
+        "zh-rTW": "陰毛",
+        "ja": "陰毛"
       },
+      "name": "阴毛",
       "search_key": "陰毛"
     },
     {
       "lang": {
         "zh-rCN": "腋毛",
         "en": "Hairy Armpits",
-        "zh-rTW": "腋毛"
+        "zh-rTW": "腋毛",
+        "ja": "腋毛"
       },
+      "name": "腋毛",
       "search_key": "腋毛"
     },
     {
       "lang": {
         "zh-rCN": "大屌",
         "en": "Big Dick",
-        "zh-rTW": "大屌"
+        "zh-rTW": "大屌",
+        "ja": "巨根"
       },
+      "name": "大屌",
       "search_key": "大屌"
     },
     {
       "lang": {
         "zh-rCN": "穿衣",
         "en": "Clothed",
-        "zh-rTW": "著衣"
+        "zh-rTW": "著衣",
+        "ja": "着衣"
       },
+      "name": "着衣",
       "search_key": "著衣"
     },
     {
       "lang": {
         "zh-rCN": "水手服",
         "en": "Sailor Suit",
-        "zh-rTW": "水手服"
+        "zh-rTW": "水手服",
+        "ja": "セーラー服"
       },
+      "name": "水手服",
       "search_key": "水手服"
     },
     {
       "lang": {
         "zh-rCN": "体操服",
         "en": "Gym Clothes",
-        "zh-rTW": "體操服"
+        "zh-rTW": "體操服",
+        "ja": "体操服"
       },
+      "name": "体操服",
       "search_key": "體操服"
     },
     {
       "lang": {
         "zh-rCN": "泳装",
         "en": "Swimsuit",
-        "zh-rTW": "泳裝"
+        "zh-rTW": "泳裝",
+        "ja": "水着"
       },
+      "name": "泳装",
       "search_key": "泳裝"
     },
     {
       "lang": {
         "zh-rCN": "比基尼",
         "en": "Bikini",
-        "zh-rTW": "比基尼"
+        "zh-rTW": "比基尼",
+        "ja": "ビキニ"
       },
+      "name": "比基尼",
       "search_key": "比基尼"
     },
     {
       "lang": {
         "zh-rCN": "死库水",
         "en": "School Swimsuit",
-        "zh-rTW": "死庫水"
+        "zh-rTW": "死庫水",
+        "ja": "スクール水着"
       },
+      "name": "死库水",
       "search_key": "死庫水"
     },
     {
       "lang": {
         "zh-rCN": "和服",
         "en": "Kimono",
-        "zh-rTW": "和服"
+        "zh-rTW": "和服",
+        "ja": "和服"
       },
+      "name": "和服",
       "search_key": "和服"
     },
     {
       "lang": {
         "zh-rCN": "兔女郎",
         "en": "Bunny Girl",
-        "zh-rTW": "兔女郎"
+        "zh-rTW": "兔女郎",
+        "ja": "バニーガール"
       },
+      "name": "兔女郎",
       "search_key": "兔女郎"
     },
     {
       "lang": {
         "zh-rCN": "围裙",
         "en": "Apron",
-        "zh-rTW": "圍裙"
+        "zh-rTW": "圍裙",
+        "ja": "エプロン"
       },
+      "name": "围裙",
       "search_key": "圍裙"
     },
     {
       "lang": {
         "zh-rCN": "啦啦队",
         "en": "Cheerleader",
-        "zh-rTW": "啦啦隊"
+        "zh-rTW": "啦啦隊",
+        "ja": "チアガール"
       },
+      "name": "啦啦队",
       "search_key": "啦啦隊"
     },
     {
       "lang": {
         "zh-rCN": "丝袜",
         "en": "Stockings",
-        "zh-rTW": "絲襪"
+        "zh-rTW": "絲襪",
+        "ja": "ストッキング"
       },
+      "name": "丝袜",
       "search_key": "絲襪"
     },
     {
       "lang": {
         "zh-rCN": "吊袜带",
         "en": "Garter Belt",
-        "zh-rTW": "吊襪帶"
+        "zh-rTW": "吊襪帶",
+        "ja": "ガーターベルト"
       },
+      "name": "吊袜带",
       "search_key": "吊襪帶"
     },
     {
       "lang": {
         "zh-rCN": "热裤",
         "en": "Hot Pants",
-        "zh-rTW": "熱褲"
+        "zh-rTW": "熱褲",
+        "ja": "ホットパンツ"
       },
+      "name": "热裤",
       "search_key": "熱褲"
     },
     {
       "lang": {
         "zh-rCN": "迷你裙",
         "en": "Mini Skirt",
-        "zh-rTW": "迷你裙"
+        "zh-rTW": "迷你裙",
+        "ja": "ミニスカート"
       },
+      "name": "迷你裙",
       "search_key": "迷你裙"
     },
     {
       "lang": {
         "zh-rCN": "性感内衣",
         "en": "Sexy Lingerie",
-        "zh-rTW": "性感內衣"
+        "zh-rTW": "性感內衣",
+        "ja": "セクシーランジェリー"
       },
+      "name": "性感内衣",
       "search_key": "性感內衣"
     },
     {
       "lang": {
         "zh-rCN": "紧身衣",
         "en": "Leotard",
-        "zh-rTW": "緊身衣"
+        "zh-rTW": "緊身衣",
+        "ja": "ボディスーツ"
       },
+      "name": "紧身衣",
       "search_key": "緊身衣"
     },
     {
       "lang": {
         "zh-rCN": "丁字裤",
         "en": "Thong",
-        "zh-rTW": "丁字褲"
+        "zh-rTW": "丁字褲",
+        "ja": "Tバック"
       },
+      "name": "丁字裤",
       "search_key": "丁字褲"
     },
     {
       "lang": {
         "zh-rCN": "高跟鞋",
         "en": "High Heels",
-        "zh-rTW": "高跟鞋"
+        "zh-rTW": "高跟鞋",
+        "ja": "ハイヒール"
       },
+      "name": "高跟鞋",
       "search_key": "高跟鞋"
     },
     {
       "lang": {
         "zh-rCN": "睡衣",
         "en": "Nightwear",
-        "zh-rTW": "睡衣"
+        "zh-rTW": "睡衣",
+        "ja": "パジャマ"
       },
+      "name": "睡衣",
       "search_key": "睡衣"
     },
     {
       "lang": {
         "zh-rCN": "婚纱",
         "en": "Bride",
-        "zh-rTW": "婚紗"
+        "zh-rTW": "婚紗",
+        "ja": "ウェディングドレス"
       },
+      "name": "婚纱",
       "search_key": "婚紗"
     },
     {
       "lang": {
         "zh-rCN": "旗袍",
         "en": "Cheongsam",
-        "zh-rTW": "旗袍"
+        "zh-rTW": "旗袍",
+        "ja": "チャイナドレス"
       },
+      "name": "旗袍",
       "search_key": "旗袍"
     },
     {
       "lang": {
         "zh-rCN": "古装",
         "en": "Ancient Costume",
-        "zh-rTW": "古裝"
+        "zh-rTW": "古裝",
+        "ja": "時代衣装"
       },
+      "name": "古装",
       "search_key": "古裝"
     },
     {
       "lang": {
         "zh-rCN": "哥特萝莉塔",
         "en": "Gothic Lolita",
-        "zh-rTW": "哥德蘿莉塔"
+        "zh-rTW": "哥德蘿莉塔",
+        "ja": "ゴスロリ"
       },
+      "name": "哥德",
       "search_key": "哥德"
     },
     {
       "lang": {
         "zh-rCN": "口罩",
         "en": "Mouth Mask",
-        "zh-rTW": "口罩"
+        "zh-rTW": "口罩",
+        "ja": "マスク"
       },
+      "name": "口罩",
       "search_key": "口罩"
     },
     {
       "lang": {
         "zh-rCN": "刺青",
         "en": "Tattoo",
-        "zh-rTW": "刺青"
+        "zh-rTW": "刺青",
+        "ja": "タトゥー"
       },
+      "name": "刺青",
       "search_key": "刺青"
     },
     {
       "lang": {
         "zh-rCN": "淫纹",
         "en": "Sexy Tattoo",
-        "zh-rTW": "淫紋"
+        "zh-rTW": "淫紋",
+        "ja": "淫紋"
       },
+      "name": "淫纹",
       "search_key": "淫紋"
     },
     {
       "lang": {
         "zh-rCN": "身体写字",
         "en": "Body Writing",
-        "zh-rTW": "身體寫字"
+        "zh-rTW": "身體寫字",
+        "ja": "身体落書き"
       },
+      "name": "身体写字",
       "search_key": "身體寫字"
     }
   ],
@@ -908,192 +1132,240 @@
       "lang": {
         "zh-rCN": "校园",
         "en": "School",
-        "zh-rTW": "校園"
+        "zh-rTW": "校園",
+        "ja": "学園"
       },
+      "name": "校园",
       "search_key": "校園"
     },
     {
       "lang": {
         "zh-rCN": "教室",
         "en": "Classroom",
-        "zh-rTW": "教室"
+        "zh-rTW": "教室",
+        "ja": "教室"
       },
+      "name": "教室",
       "search_key": "教室"
     },
     {
       "lang": {
         "zh-rCN": "图书馆",
         "en": "Library",
-        "zh-rTW": "圖書館"
+        "zh-rTW": "圖書館",
+        "ja": "図書館"
       },
+      "name": "图书馆",
       "search_key": "圖書館"
     },
     {
       "lang": {
         "zh-rCN": "保健室",
         "en": "Health Room",
-        "zh-rTW": "保健室"
+        "zh-rTW": "保健室",
+        "ja": "保健室"
       },
+      "name": "保健室",
       "search_key": "保健室"
     },
     {
       "lang": {
         "zh-rCN": "游泳池",
         "en": "Swimming Pool",
-        "zh-rTW": "游泳池"
+        "zh-rTW": "游泳池",
+        "ja": "プール"
       },
+      "name": "游泳池",
       "search_key": "游泳池"
     },
     {
       "lang": {
         "zh-rCN": "爱情宾馆",
         "en": "Love Hotel",
-        "zh-rTW": "愛情賓館"
+        "zh-rTW": "愛情賓館",
+        "ja": "ラブホテル"
       },
+      "name": "爱情宾馆",
       "search_key": "愛情賓館"
     },
     {
       "lang": {
         "zh-rCN": "医院",
         "en": "Hospital",
-        "zh-rTW": "醫院"
+        "zh-rTW": "醫院",
+        "ja": "病院"
       },
+      "name": "医院",
       "search_key": "醫院"
     },
     {
       "lang": {
         "zh-rCN": "办公室",
         "en": "Office",
-        "zh-rTW": "辦公室"
+        "zh-rTW": "辦公室",
+        "ja": "オフィス"
       },
+      "name": "办公室",
       "search_key": "辦公室"
     },
     {
       "lang": {
         "zh-rCN": "浴室",
         "en": "Bathroom",
-        "zh-rTW": "浴室"
+        "zh-rTW": "浴室",
+        "ja": "浴室"
       },
+      "name": "浴室",
       "search_key": "浴室"
     },
     {
       "lang": {
         "zh-rCN": "窗边",
         "en": "By the Window",
-        "zh-rTW": "窗邊"
+        "zh-rTW": "窗邊",
+        "ja": "窓辺"
       },
+      "name": "窗边",
       "search_key": "窗邊"
     },
     {
       "lang": {
         "zh-rCN": "公共厕所",
         "en": "Public Toilet",
-        "zh-rTW": "公共廁所"
+        "zh-rTW": "公共廁所",
+        "ja": "公衆トイレ"
       },
+      "name": "公共厕所",
       "search_key": "公共廁所"
     },
     {
       "lang": {
         "zh-rCN": "公共场合",
         "en": "Public Place",
-        "zh-rTW": "公眾場合"
+        "zh-rTW": "公眾場合",
+        "ja": "公共の場"
       },
+      "name": "公众场合",
       "search_key": "公眾場合"
     },
     {
       "lang": {
         "zh-rCN": "户外野战",
         "en": "Outdoor Sex",
-        "zh-rTW": "戶外野戰"
+        "zh-rTW": "戶外野戰",
+        "ja": "野外"
       },
+      "name": "户外野战",
       "search_key": "戶外野戰"
     },
     {
       "lang": {
         "zh-rCN": "电车",
         "en": "Train",
-        "zh-rTW": "電車"
+        "zh-rTW": "電車",
+        "ja": "電車"
       },
+      "name": "电车",
       "search_key": "電車"
     },
     {
       "lang": {
         "zh-rCN": "车震",
         "en": "Car Sex",
-        "zh-rTW": "車震"
+        "zh-rTW": "車震",
+        "ja": "カーセックス"
       },
+      "name": "车震",
       "search_key": "車震"
     },
     {
       "lang": {
         "zh-rCN": "游艇",
         "en": "Yacht",
-        "zh-rTW": "遊艇"
+        "zh-rTW": "遊艇",
+        "ja": "ヨット"
       },
+      "name": "游艇",
       "search_key": "遊艇"
     },
     {
       "lang": {
         "zh-rCN": "露营帐篷",
         "en": "Camping Tent",
-        "zh-rTW": "露營帳篷"
+        "zh-rTW": "露營帳篷",
+        "ja": "キャンプテント"
       },
+      "name": "露营帐篷",
       "search_key": "露營帳篷"
     },
     {
       "lang": {
         "zh-rCN": "电影院",
         "en": "Cinema",
-        "zh-rTW": "電影院"
+        "zh-rTW": "電影院",
+        "ja": "映画館"
       },
+      "name": "电影院",
       "search_key": "電影院"
     },
     {
       "lang": {
         "zh-rCN": "健身房",
         "en": "Gym",
-        "zh-rTW": "健身房"
+        "zh-rTW": "健身房",
+        "ja": "ジム"
       },
+      "name": "健身房",
       "search_key": "健身房"
     },
     {
       "lang": {
         "zh-rCN": "沙滩",
         "en": "Beach",
-        "zh-rTW": "沙灘"
+        "zh-rTW": "沙灘",
+        "ja": "ビーチ"
       },
+      "name": "沙滩",
       "search_key": "沙灘"
     },
     {
       "lang": {
         "zh-rCN": "温泉",
         "en": "Hot Spring",
-        "zh-rTW": "溫泉"
+        "zh-rTW": "溫泉",
+        "ja": "温泉"
       },
+      "name": "温泉",
       "search_key": "溫泉"
     },
     {
       "lang": {
         "zh-rCN": "夜店",
         "en": "Nightclub",
-        "zh-rTW": "夜店"
+        "zh-rTW": "夜店",
+        "ja": "ナイトクラブ"
       },
+      "name": "夜店",
       "search_key": "夜店"
     },
     {
       "lang": {
         "zh-rCN": "监狱",
         "en": "Prison",
-        "zh-rTW": "監獄"
+        "zh-rTW": "監獄",
+        "ja": "監獄"
       },
+      "name": "监狱",
       "search_key": "監獄"
     },
     {
       "lang": {
         "zh-rCN": "教堂",
         "en": "Church",
-        "zh-rTW": "教堂"
+        "zh-rTW": "教堂",
+        "ja": "教会"
       },
+      "name": "教堂",
       "search_key": "教堂"
     }
   ],
@@ -1102,360 +1374,450 @@
       "lang": {
         "zh-rCN": "纯爱",
         "en": "Pure Love",
-        "zh-rTW": "純愛"
+        "zh-rTW": "純愛",
+        "ja": "純愛"
       },
+      "name": "纯爱",
       "search_key": "純愛"
     },
     {
       "lang": {
         "zh-rCN": "恋爱喜剧",
         "en": "Romantic Comedy",
-        "zh-rTW": "戀愛喜劇"
+        "zh-rTW": "戀愛喜劇",
+        "ja": "ラブコメ"
       },
+      "name": "恋爱喜剧",
       "search_key": "戀愛喜劇"
     },
     {
       "lang": {
         "zh-rCN": "后宫",
         "en": "Harem",
-        "zh-rTW": "後宮"
+        "zh-rTW": "後宮",
+        "ja": "ハーレム"
       },
+      "name": "后宫",
       "search_key": "後宮"
     },
     {
       "lang": {
         "zh-rCN": "十指紧扣",
         "en": "Interlocked fingers",
-        "zh-rTW": "十指緊扣"
+        "zh-rTW": "十指緊扣",
+        "ja": "恋人つなぎ"
       },
+      "name": "十指紧扣",
       "search_key": "十指緊扣"
     },
     {
       "lang": {
         "zh-rCN": "开大车",
         "en": "Older Woman Younger Man",
-        "zh-rTW": "開大車"
+        "zh-rTW": "開大車",
+        "ja": "おねショタ"
       },
+      "name": "开大车",
       "search_key": "開大車"
     },
     {
       "lang": {
         "zh-rCN": "NTR",
         "en": "NTR",
-        "zh-rTW": "NTR"
+        "zh-rTW": "NTR",
+        "ja": "NTR"
       },
+      "name": "NTR",
       "search_key": "NTR"
     },
     {
       "lang": {
         "zh-rCN": "精神控制",
         "en": "Mind Control",
-        "zh-rTW": "精神控制"
+        "zh-rTW": "精神控制",
+        "ja": "精神支配"
       },
+      "name": "精神控制",
       "search_key": "精神控制"
     },
     {
       "lang": {
         "zh-rCN": "药物",
         "en": "Drugs",
-        "zh-rTW": "藥物"
+        "zh-rTW": "藥物",
+        "ja": "薬物"
       },
+      "name": "药物",
       "search_key": "藥物"
     },
     {
       "lang": {
         "zh-rCN": "痴汉",
         "en": "Chikan/Molester",
-        "zh-rTW": "痴漢"
+        "zh-rTW": "痴漢",
+        "ja": "痴漢"
       },
+      "name": "痴汉",
       "search_key": "痴漢"
     },
     {
       "lang": {
         "zh-rCN": "阿嘿颜",
         "en": "Ahegao",
-        "zh-rTW": "阿嘿顏"
+        "zh-rTW": "阿嘿顏",
+        "ja": "アヘ顔"
       },
+      "name": "阿嘿颜",
       "search_key": "阿嘿顏"
     },
     {
       "lang": {
         "zh-rCN": "精神崩溃",
         "en": "Mental Breakdown",
-        "zh-rTW": "精神崩潰"
+        "zh-rTW": "精神崩潰",
+        "ja": "精神崩壊"
       },
+      "name": "精神崩溃",
       "search_key": "精神崩潰"
     },
     {
       "lang": {
         "zh-rCN": "猎奇",
         "en": "Guro/Gore",
-        "zh-rTW": "獵奇"
+        "zh-rTW": "獵奇",
+        "ja": "猟奇"
       },
+      "name": "猎奇",
       "search_key": "獵奇"
     },
     {
       "lang": {
         "zh-rCN": "BDSM",
         "en": "BDSM",
-        "zh-rTW": "BDSM"
+        "zh-rTW": "BDSM",
+        "ja": "BDSM"
       },
+      "name": "BDSM",
       "search_key": "BDSM"
     },
     {
       "lang": {
         "zh-rCN": "捆绑",
         "en": "Bondage",
-        "zh-rTW": "綑綁"
+        "zh-rTW": "綑綁",
+        "ja": "緊縛"
       },
+      "name": "捆绑",
       "search_key": "綑綁"
     },
     {
       "lang": {
         "zh-rCN": "眼罩",
         "en": "Blindfold",
-        "zh-rTW": "眼罩"
+        "zh-rTW": "眼罩",
+        "ja": "目隠し"
       },
+      "name": "眼罩",
       "search_key": "眼罩"
     },
     {
       "lang": {
         "zh-rCN": "项圈",
         "en": "Collar",
-        "zh-rTW": "項圈"
+        "zh-rTW": "項圈",
+        "ja": "首輪"
       },
+      "name": "项圈",
       "search_key": "項圈"
     },
     {
       "lang": {
         "zh-rCN": "调教",
         "en": "Taming/Training",
-        "zh-rTW": "調教"
+        "zh-rTW": "調教",
+        "ja": "調教"
       },
+      "name": "调教",
       "search_key": "調教"
     },
     {
       "lang": {
         "zh-rCN": "异物插入",
         "en": "Foreign Object Insertion",
-        "zh-rTW": "異物插入"
+        "zh-rTW": "異物插入",
+        "ja": "異物挿入"
       },
+      "name": "异物插入",
       "search_key": "異物插入"
     },
     {
       "lang": {
         "zh-rCN": "寻欢洞",
         "en": "Glory Hole",
-        "zh-rTW": "尋歡洞"
+        "zh-rTW": "尋歡洞",
+        "ja": "グローリーホール"
       },
+      "name": "寻欢洞",
       "search_key": "尋歡洞"
     },
     {
       "lang": {
         "zh-rCN": "肉便器",
         "en": "Human Toilet",
-        "zh-rTW": "肉便器"
+        "zh-rTW": "肉便器",
+        "ja": "肉便器"
       },
+      "name": "肉便器",
       "search_key": "肉便器"
     },
     {
       "lang": {
         "zh-rCN": "性奴隶",
         "en": "Sex Slave",
-        "zh-rTW": "性奴隸"
+        "zh-rTW": "性奴隸",
+        "ja": "性奴隷"
       },
+      "name": "性奴隶",
       "search_key": "性奴隸"
     },
     {
       "lang": {
         "zh-rCN": "胃凸",
         "en": "Stomach Bulge",
-        "zh-rTW": "胃凸"
+        "zh-rTW": "胃凸",
+        "ja": "胃凸"
       },
+      "name": "胃凸",
       "search_key": "胃凸"
     },
     {
       "lang": {
         "zh-rCN": "强制",
         "en": "Forced/Non-Con",
-        "zh-rTW": "強制"
+        "zh-rTW": "強制",
+        "ja": "強制"
       },
+      "name": "强制",
       "search_key": "強制"
     },
     {
       "lang": {
         "zh-rCN": "轮奸",
         "en": "Gangbang",
-        "zh-rTW": "輪姦"
+        "zh-rTW": "輪姦",
+        "ja": "輪姦"
       },
+      "name": "轮奸",
       "search_key": "輪姦"
     },
     {
       "lang": {
         "zh-rCN": "凌辱",
         "en": "Humiliation",
-        "zh-rTW": "凌辱"
+        "zh-rTW": "凌辱",
+        "ja": "凌辱"
       },
+      "name": "凌辱",
       "search_key": "凌辱"
     },
     {
       "lang": {
         "zh-rCN": "性暴力",
         "en": "Sexual Violence",
-        "zh-rTW": "性暴力"
+        "zh-rTW": "性暴力",
+        "ja": "性暴力"
       },
+      "name": "性暴力",
       "search_key": "性暴力"
     },
     {
       "lang": {
         "zh-rCN": "逆强制",
         "en": "Reverse Non-Con",
-        "zh-rTW": "逆強制"
+        "zh-rTW": "逆強制",
+        "ja": "逆強制"
       },
+      "name": "逆强制",
       "search_key": "逆強制"
     },
     {
       "lang": {
         "zh-rCN": "女王大人",
         "en": "Queen/Dominatrix",
-        "zh-rTW": "女王樣"
+        "zh-rTW": "女王樣",
+        "ja": "女王様"
       },
+      "name": "女王样",
       "search_key": "女王樣"
     },
     {
       "lang": {
         "zh-rCN": "榨精",
         "en": "Semen collection",
-        "zh-rTW": "榨精"
+        "zh-rTW": "榨精",
+        "ja": "搾精"
       },
+      "name": "榨精",
       "search_key": "榨精"
     },
     {
       "lang": {
         "zh-rCN": "母女丼",
         "en": "Mother and Daughter",
-        "zh-rTW": "母女丼"
+        "zh-rTW": "母女丼",
+        "ja": "母娘丼"
       },
+      "name": "母女丼",
       "search_key": "母女丼"
     },
     {
       "lang": {
         "zh-rCN": "姐妹丼",
         "en": "Sisters",
-        "zh-rTW": "姐妹丼"
+        "zh-rTW": "姐妹丼",
+        "ja": "姉妹丼"
       },
+      "name": "姐妹丼",
       "search_key": "姐妹丼"
     },
     {
       "lang": {
         "zh-rCN": "出轨",
         "en": "Cheating/Infidelity",
-        "zh-rTW": "出軌"
+        "zh-rTW": "出軌",
+        "ja": "浮気"
       },
+      "name": "出轨",
       "search_key": "出軌"
     },
     {
       "lang": {
         "zh-rCN": "醉酒",
         "en": "Drunk",
-        "zh-rTW": "醉酒"
+        "zh-rTW": "醉酒",
+        "ja": "酔酒"
       },
+      "name": "醉酒",
       "search_key": "醉酒"
     },
     {
       "lang": {
         "zh-rCN": "摄影",
         "en": "Filming/Photography",
-        "zh-rTW": "攝影"
+        "zh-rTW": "攝影",
+        "ja": "撮影"
       },
+      "name": "摄影",
       "search_key": "攝影"
     },
     {
       "lang": {
         "zh-rCN": "睡眠奸",
         "en": "Sleep Rape",
-        "zh-rTW": "睡眠姦"
+        "zh-rTW": "睡眠姦",
+        "ja": "睡眠姦"
       },
+      "name": "睡眠奸",
       "search_key": "睡眠姦"
     },
     {
       "lang": {
         "zh-rCN": "机械奸",
         "en": "Machine Rape",
-        "zh-rTW": "機械姦"
+        "zh-rTW": "機械姦",
+        "ja": "機械姦"
       },
+      "name": "机械奸",
       "search_key": "機械姦"
     },
     {
       "lang": {
         "zh-rCN": "虫奸",
         "en": "Insect Rape",
-        "zh-rTW": "蟲姦"
+        "zh-rTW": "蟲姦",
+        "ja": "虫姦"
       },
+      "name": "虫奸",
       "search_key": "蟲姦"
     },
     {
       "lang": {
         "zh-rCN": "性转换",
         "en": "Gender Transformation",
-        "zh-rTW": "性轉換"
+        "zh-rTW": "性轉換",
+        "ja": "性転換"
       },
+      "name": "性转换",
       "search_key": "性轉換"
     },
     {
       "lang": {
         "zh-rCN": "百合",
         "en": "Yuri/Lesbian",
-        "zh-rTW": "百合"
+        "zh-rTW": "百合",
+        "ja": "百合"
       },
+      "name": "百合",
       "search_key": "百合"
     },
     {
       "lang": {
         "zh-rCN": "耽美",
         "en": "BL/Yaoi",
-        "zh-rTW": "耽美"
+        "zh-rTW": "耽美",
+        "ja": "BL"
       },
+      "name": "耽美",
       "search_key": "耽美"
     },
     {
       "lang": {
         "zh-rCN": "时间停止",
         "en": "Time Stop",
-        "zh-rTW": "時間停止"
+        "zh-rTW": "時間停止",
+        "ja": "時間停止"
       },
+      "name": "时间停止",
       "search_key": "時間停止"
     },
     {
       "lang": {
         "zh-rCN": "异世界",
         "en": "Isekai",
-        "zh-rTW": "異世界"
+        "zh-rTW": "異世界",
+        "ja": "異世界"
       },
+      "name": "异世界",
       "search_key": "異世界"
     },
     {
       "lang": {
         "zh-rCN": "怪兽",
         "en": "Monster",
-        "zh-rTW": "怪獸"
+        "zh-rTW": "怪獸",
+        "ja": "怪獣"
       },
+      "name": "怪兽",
       "search_key": "怪獸"
     },
     {
       "lang": {
         "zh-rCN": "哥布林",
         "en": "Goblin",
-        "zh-rTW": "哥布林"
+        "zh-rTW": "哥布林",
+        "ja": "ゴブリン"
       },
+      "name": "哥布林",
       "search_key": "哥布林"
     },
     {
       "lang": {
         "zh-rCN": "世界末日",
         "en": "Apocalypse",
-        "zh-rTW": "世界末日"
+        "zh-rTW": "世界末日",
+        "ja": "世界末日"
       },
+      "name": "世界末日",
       "search_key": "世界末日"
     }
   ],
@@ -1464,432 +1826,540 @@
       "lang": {
         "zh-rCN": "手交",
         "en": "Handjob",
-        "zh-rTW": "手交"
+        "zh-rTW": "手交",
+        "ja": "手コキ"
       },
+      "name": "手交",
       "search_key": "手交"
     },
     {
       "lang": {
         "zh-rCN": "指交",
         "en": "Fingering",
-        "zh-rTW": "指交"
+        "zh-rTW": "指交",
+        "ja": "指入れ"
       },
+      "name": "指交",
       "search_key": "指交"
     },
     {
       "lang": {
         "zh-rCN": "乳交",
         "en": "Titty fuck",
-        "zh-rTW": "乳交"
+        "zh-rTW": "乳交",
+        "ja": "パイズリ"
       },
+      "name": "乳交",
       "search_key": "乳交"
     },
     {
       "lang": {
         "zh-rCN": "乳头交",
         "en": "Nipple Stimulation",
-        "zh-rTW": "乳頭交"
+        "zh-rTW": "乳頭交",
+        "ja": "乳首責め"
       },
+      "name": "乳头交",
       "search_key": "乳頭交"
     },
     {
       "lang": {
         "zh-rCN": "肛交",
         "en": "Anal Sex",
-        "zh-rTW": "肛交"
+        "zh-rTW": "肛交",
+        "ja": "アナル"
       },
+      "name": "肛交",
       "search_key": "肛交"
     },
     {
       "lang": {
         "zh-rCN": "双洞齐下",
         "en": "Double Penetration",
-        "zh-rTW": "雙洞齊下"
+        "zh-rTW": "雙洞齊下",
+        "ja": "二穴責め"
       },
+      "name": "双洞齐下",
       "search_key": "雙洞齊下"
     },
     {
       "lang": {
         "zh-rCN": "足交",
         "en": "Footjob",
-        "zh-rTW": "腳交"
+        "zh-rTW": "腳交",
+        "ja": "足コキ"
       },
+      "name": "脚交",
       "search_key": "腳交"
     },
     {
       "lang": {
         "zh-rCN": "素股",
         "en": "Sumata/Thigh Sex",
-        "zh-rTW": "素股"
+        "zh-rTW": "素股",
+        "ja": "素股"
       },
+      "name": "素股",
       "search_key": "素股"
     },
     {
       "lang": {
         "zh-rCN": "拳交",
         "en": "Fisting",
-        "zh-rTW": "拳交"
+        "zh-rTW": "拳交",
+        "ja": "フィスト"
       },
+      "name": "拳交",
       "search_key": "拳交"
     },
     {
       "lang": {
         "zh-rCN": "3P",
         "en": "3P",
-        "zh-rTW": "3P"
+        "zh-rTW": "3P",
+        "ja": "3P"
       },
+      "name": "3P",
       "search_key": "3P"
     },
     {
       "lang": {
         "zh-rCN": "群交",
         "en": "Orgy",
-        "zh-rTW": "群交"
+        "zh-rTW": "群交",
+        "ja": "乱交"
       },
+      "name": "群交",
       "search_key": "群交"
     },
     {
       "lang": {
         "zh-rCN": "口交",
         "en": "Oral Sex",
-        "zh-rTW": "口交"
+        "zh-rTW": "口交",
+        "ja": "フェラ"
       },
+      "name": "口交",
       "search_key": "口交"
     },
     {
       "lang": {
         "zh-rCN": "跪舔",
         "en": "Grovel",
-        "zh-rTW": "跪舔"
+        "zh-rTW": "跪舔",
+        "ja": "跪き舐め"
       },
+      "name": "跪舔",
       "search_key": "跪舔"
     },
     {
       "lang": {
         "zh-rCN": "深喉",
         "en": "Deepthroat",
-        "zh-rTW": "深喉嚨"
+        "zh-rTW": "深喉嚨",
+        "ja": "ディープスロート"
       },
+      "name": "深喉咙",
       "search_key": "深喉嚨"
     },
     {
       "lang": {
         "zh-rCN": "口爆",
         "en": "Cum in Mouth",
-        "zh-rTW": "口爆"
+        "zh-rTW": "口爆",
+        "ja": "口内射精"
       },
+      "name": "口爆",
       "search_key": "口爆"
     },
     {
       "lang": {
         "zh-rCN": "吞精",
         "en": "Swallowing Cum",
-        "zh-rTW": "吞精"
+        "zh-rTW": "吞精",
+        "ja": "ごっくん"
       },
+      "name": "吞精",
       "search_key": "吞精"
     },
     {
       "lang": {
         "zh-rCN": "舔蛋蛋",
         "en": "Ball Licking",
-        "zh-rTW": "舔蛋蛋"
+        "zh-rTW": "舔蛋蛋",
+        "ja": "睾丸舐め"
       },
+      "name": "舔蛋蛋",
       "search_key": "舔蛋蛋"
     },
     {
       "lang": {
         "zh-rCN": "舔穴",
         "en": "Pussy Licking",
-        "zh-rTW": "舔穴"
+        "zh-rTW": "舔穴",
+        "ja": "クンニ"
       },
+      "name": "舔穴",
       "search_key": "舔穴"
     },
     {
       "lang": {
         "zh-rCN": "69",
         "en": "69",
-        "zh-rTW": "69"
+        "zh-rTW": "69",
+        "ja": "69"
       },
+      "name": "69",
       "search_key": "69"
     },
     {
       "lang": {
         "zh-rCN": "自慰",
         "en": "Masturbation",
-        "zh-rTW": "自慰"
+        "zh-rTW": "自慰",
+        "ja": "オナニー"
       },
+      "name": "自慰",
       "search_key": "自慰"
     },
     {
       "lang": {
         "zh-rCN": "腋交",
         "en": "Armpit Sex",
-        "zh-rTW": "腋交"
+        "zh-rTW": "腋交",
+        "ja": "腋コキ"
       },
+      "name": "腋交",
       "search_key": "腋交"
     },
     {
       "lang": {
         "zh-rCN": "舔腋下",
         "en": "Armpit Licking",
-        "zh-rTW": "舔腋下"
+        "zh-rTW": "舔腋下",
+        "ja": "腋舐め"
       },
+      "name": "舔腋下",
       "search_key": "舔腋下"
     },
     {
       "lang": {
         "zh-rCN": "发交",
         "en": "Hair Sex",
-        "zh-rTW": "髮交"
+        "zh-rTW": "髮交",
+        "ja": "髪コキ"
       },
+      "name": "发交",
       "search_key": "髮交"
     },
     {
       "lang": {
         "zh-rCN": "舔耳朵",
         "en": "Ear Licking",
-        "zh-rTW": "舔耳朵"
+        "zh-rTW": "舔耳朵",
+        "ja": "耳舐め"
       },
+      "name": "舔耳朵",
       "search_key": "舔耳朵"
     },
     {
       "lang": {
         "zh-rCN": "舔脚",
         "en": "Feet Licking",
-        "zh-rTW": "舔腳"
+        "zh-rTW": "舔腳",
+        "ja": "足舐め"
       },
+      "name": "舔脚",
       "search_key": "舔腳"
     },
     {
       "lang": {
         "zh-rCN": "内射",
         "en": "Internal Ejaculation",
-        "zh-rTW": "內射"
+        "zh-rTW": "內射",
+        "ja": "中出し"
       },
+      "name": "内射",
       "search_key": "內射"
     },
     {
       "lang": {
         "zh-rCN": "外射",
         "en": "External Ejaculation",
-        "zh-rTW": "外射"
+        "zh-rTW": "外射",
+        "ja": "外出し"
       },
+      "name": "外射",
       "search_key": "外射"
     },
     {
       "lang": {
         "zh-rCN": "顏射",
         "en": "Facial",
-        "zh-rTW": "顏射"
+        "zh-rTW": "顏射",
+        "ja": "顔射"
       },
+      "name": "颜射",
       "search_key": "顏射"
     },
     {
       "lang": {
         "zh-rCN": "潮吹",
         "en": "Squirting",
-        "zh-rTW": "潮吹"
+        "zh-rTW": "潮吹",
+        "ja": "潮吹き"
       },
+      "name": "潮吹",
       "search_key": "潮吹"
     },
     {
       "lang": {
         "zh-rCN": "怀孕",
         "en": "Pregnancy",
-        "zh-rTW": "懷孕"
+        "zh-rTW": "懷孕",
+        "ja": "妊娠"
       },
+      "name": "怀孕",
       "search_key": "懷孕"
     },
     {
       "lang": {
         "zh-rCN": "喷奶",
         "en": "Lactation",
-        "zh-rTW": "噴奶"
+        "zh-rTW": "噴奶",
+        "ja": "母乳"
       },
+      "name": "喷奶",
       "search_key": "噴奶"
     },
     {
       "lang": {
         "zh-rCN": "放尿",
         "en": "Urinating",
-        "zh-rTW": "放尿"
+        "zh-rTW": "放尿",
+        "ja": "放尿"
       },
+      "name": "放尿",
       "search_key": "放尿"
     },
     {
       "lang": {
         "zh-rCN": "排便",
         "en": "Defecation",
-        "zh-rTW": "排便"
+        "zh-rTW": "排便",
+        "ja": "排便"
       },
+      "name": "排便",
       "search_key": "排便"
     },
     {
       "lang": {
         "zh-rCN": "骑乘位",
         "en": "Riding Position",
-        "zh-rTW": "騎乘位"
+        "zh-rTW": "騎乘位",
+        "ja": "騎乗位"
       },
+      "name": "骑乘位",
       "search_key": "騎乘位"
     },
     {
       "lang": {
-        "zh-rCN": "后背位",
+        "zh-rCN": "背后位",
         "en": "Doggy Style",
-        "zh-rTW": "背後位"
+        "zh-rTW": "背後位",
+        "ja": "バック"
       },
+      "name": "背后位",
       "search_key": "背後位"
     },
     {
       "lang": {
-        "zh-rCN": "顏面騎乘",
+        "zh-rCN": "颜面骑乘",
         "en": "Facesitting",
-        "zh-rTW": "顏面騎乘"
+        "zh-rTW": "顏面騎乘",
+        "ja": "顔面騎乗"
       },
+      "name": "颜面骑乘",
       "search_key": "顏面騎乘"
     },
     {
       "lang": {
         "zh-rCN": "火车便当",
         "en": "Tate Dama",
-        "zh-rTW": "火車便當"
+        "zh-rTW": "火車便當",
+        "ja": "駅弁"
       },
+      "name": "火车便当",
       "search_key": "火車便當"
     },
     {
       "lang": {
         "zh-rCN": "一字马",
         "en": "Do the splits",
-        "zh-rTW": "一字馬"
+        "zh-rTW": "一字馬",
+        "ja": "開脚"
       },
+      "name": "一字马",
       "search_key": "一字馬"
     },
     {
       "lang": {
         "zh-rCN": "性玩具",
         "en": "Sex Toys",
-        "zh-rTW": "性玩具"
+        "zh-rTW": "性玩具",
+        "ja": "性玩具"
       },
+      "name": "性玩具",
       "search_key": "性玩具"
     },
     {
       "lang": {
         "zh-rCN": "飞机杯",
         "en": "Onahole",
-        "zh-rTW": "飛機杯"
+        "zh-rTW": "飛機杯",
+        "ja": "オナホ"
       },
+      "name": "飞机杯",
       "search_key": "飛機杯"
     },
     {
       "lang": {
         "zh-rCN": "跳蛋",
         "en": "Vibrating Egg",
-        "zh-rTW": "跳蛋"
+        "zh-rTW": "跳蛋",
+        "ja": "ローター"
       },
+      "name": "跳蛋",
       "search_key": "跳蛋"
     },
     {
       "lang": {
         "zh-rCN": "毒龙钻",
         "en": "Rimjob",
-        "zh-rTW": "毒龍鑽"
+        "zh-rTW": "毒龍鑽",
+        "ja": "ドリル責め"
       },
+      "name": "毒龙钻",
       "search_key": "毒龍鑽"
     },
     {
       "lang": {
         "zh-rCN": "触手",
         "en": "Tentacles",
-        "zh-rTW": "觸手"
+        "zh-rTW": "觸手",
+        "ja": "触手"
       },
+      "name": "触手",
       "search_key": "觸手"
     },
     {
       "lang": {
         "zh-rCN": "兽交",
         "en": "Bestiality",
-        "zh-rTW": "獸交"
+        "zh-rTW": "獸交",
+        "ja": "獣姦"
       },
+      "name": "兽交",
       "search_key": "獸交"
     },
     {
       "lang": {
         "zh-rCN": "颈手枷",
         "en": "Stocks",
-        "zh-rTW": "頸手枷"
+        "zh-rTW": "頸手枷",
+        "ja": "首手枷"
       },
+      "name": "颈手枷",
       "search_key": "頸手枷"
     },
     {
       "lang": {
         "zh-rCN": "扯头发",
         "en": "Hair pulling",
-        "zh-rTW": "扯頭髮"
+        "zh-rTW": "扯頭髮",
+        "ja": "髪引っ張り"
       },
+      "name": "扯头发",
       "search_key": "扯頭髮"
     },
     {
       "lang": {
         "zh-rCN": "掐脖子",
         "en": "Choking",
-        "zh-rTW": "掐脖子"
+        "zh-rTW": "掐脖子",
+        "ja": "首絞め"
       },
+      "name": "掐脖子",
       "search_key": "掐脖子"
     },
     {
       "lang": {
         "zh-rCN": "打屁股",
         "en": "Spanking",
-        "zh-rTW": "打屁股"
+        "zh-rTW": "打屁股",
+        "ja": "スパンキング"
       },
+      "name": "打屁股",
       "search_key": "打屁股"
     },
     {
       "lang": {
         "zh-rCN": "肉棒打脸",
         "en": "Cock Slap",
-        "zh-rTW": "肉棒打臉"
+        "zh-rTW": "肉棒打臉",
+        "ja": "肉棒ビンタ"
       },
+      "name": "肉棒打脸",
       "search_key": "肉棒打臉"
     },
     {
       "lang": {
         "zh-rCN": "阴道外翻",
         "en": "Vaginal Eversion",
-        "zh-rTW": "陰道外翻"
+        "zh-rTW": "陰道外翻",
+        "ja": "膣外反"
       },
+      "name": "阴道外翻",
       "search_key": "陰道外翻"
     },
     {
       "lang": {
         "zh-rCN": "男乳首责",
         "en": "Male tit torture",
-        "zh-rTW": "男乳首責"
+        "zh-rTW": "男乳首責",
+        "ja": "男乳首責め"
       },
+      "name": "男乳首责",
       "search_key": "男乳首責"
     },
     {
       "lang": {
         "zh-rCN": "接吻",
         "en": "Kissing",
-        "zh-rTW": "接吻"
+        "zh-rTW": "接吻",
+        "ja": "キス"
       },
+      "name": "接吻",
       "search_key": "接吻"
     },
     {
       "lang": {
         "zh-rCN": "舌吻",
         "en": "French Kissing",
-        "zh-rTW": "舌吻"
+        "zh-rTW": "舌吻",
+        "ja": "ディープキス"
       },
+      "name": "舌吻",
       "search_key": "舌吻"
     },
     {
       "lang": {
         "zh-rCN": "POV",
         "en": "POV",
-        "zh-rTW": "POV"
+        "zh-rTW": "POV",
+        "ja": "POV"
       },
+      "name": "POV",
       "search_key": "POV"
     }
   ]

--- a/app/src/main/java/com/yenaly/han1meviewer/logic/Parser.kt
+++ b/app/src/main/java/com/yenaly/han1meviewer/logic/Parser.kt
@@ -46,7 +46,7 @@ object Parser {
      */
     object Regex {
         val videoSource = Regex("""const source = '(.+)'""")
-        val viewAndUploadTime = Regex("""(觀看次數|观看次数)：(.+)次 *(\d{4}-\d{2}-\d{2})""")
+        val viewAndUploadTime = Regex("""(觀看次數|观看次数)：(.+次) *(\d{4}-\d{2}-\d{2})""")
     }
 
     fun extractTokenFromLoginPage(body: String): String {

--- a/app/src/main/java/com/yenaly/han1meviewer/logic/model/ReportReason.kt
+++ b/app/src/main/java/com/yenaly/han1meviewer/logic/model/ReportReason.kt
@@ -25,6 +25,8 @@ data class ReportReason(
         val zhrTW: String? = null,
         @SerialName("en")
         val en: String? = null,
+        @SerialName("ja")
+        val ja: String? = null,
     ) : Parcelable
 
     override fun hashCode(): Int = reasonKey?.hashCode() ?: 0
@@ -40,6 +42,7 @@ data class ReportReason(
                     else -> lang.zhrTW
                 }
                 Locale.ENGLISH.language -> lang.en
+                Locale.JAPANESE.language -> lang.ja
                 else -> lang.zhrTW
             } ?: lang.zhrTW.orEmpty()
         }

--- a/app/src/main/java/com/yenaly/han1meviewer/logic/model/SearchOption.kt
+++ b/app/src/main/java/com/yenaly/han1meviewer/logic/model/SearchOption.kt
@@ -64,6 +64,8 @@ data class SearchOption(
         val zhrTW: String? = null,
         @SerialName("en")
         val en: String? = null,
+        @SerialName("ja")
+        val ja: String? = null,
     ) : Parcelable
 
     override fun hashCode(): Int = searchKey.hashCode()
@@ -71,7 +73,7 @@ data class SearchOption(
     val value: String
         get() = when {
             lang == null -> name.orEmpty()
-            name == null -> LanguageHelper.preferredLanguage.let { pl ->
+            else -> LanguageHelper.preferredLanguage.let { pl ->
                 when (pl.language) {
                     Locale.CHINESE.language -> when (pl.country) {
                         Locale.SIMPLIFIED_CHINESE.country -> lang.zhrCN
@@ -79,10 +81,9 @@ data class SearchOption(
                     }
 
                     Locale.ENGLISH.language -> lang.en
+                    Locale.JAPANESE.language -> lang.ja
                     else -> lang.zhrTW
                 }
             } ?: lang.zhrTW.orEmpty()
-
-            else -> throw IllegalArgumentException("Unknown lang type: ${lang.javaClass.name}")
         }
 }

--- a/app/src/main/java/com/yenaly/han1meviewer/ui/component/ExpandableRichText.kt
+++ b/app/src/main/java/com/yenaly/han1meviewer/ui/component/ExpandableRichText.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
@@ -70,33 +71,35 @@ fun ExpandableRichText(
                 transitionSpec = { fadeIn() togetherWith fadeOut() },
                 label = "expandable-rich-text",
             ) { isExpanded ->
-                Text(
-                    text = annotatedText,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = if (isExpanded) Int.MAX_VALUE else maxCollapsedLines,
-                    overflow = if (isExpanded) TextOverflow.Clip else TextOverflow.Ellipsis,
-                    onTextLayout = { result ->
-                        layoutResult = result
-                        if (!isExpanded) {
-                            hasOverflow = result.hasVisualOverflow
-                        }
-                    },
-                    modifier = Modifier.pointerInput(annotatedText, layoutResult) {
-                        detectTapGestures { tapOffset ->
-                            val result = layoutResult ?: return@detectTapGestures
-                            val offset = result.getOffsetForPosition(tapOffset)
-                            annotatedText
-                                .getStringAnnotations(UrlAnnotationTag, offset, offset)
-                                .firstOrNull()
-                                ?.item
-                                ?.let { url ->
-                                    if (onLinkClick != null) onLinkClick(url)
-                                    else uriHandler.openUri(url)
-                                }
-                        }
-                    },
-                )
+                SelectionContainer {
+                    Text(
+                        text = annotatedText,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = if (isExpanded) Int.MAX_VALUE else maxCollapsedLines,
+                        overflow = if (isExpanded) TextOverflow.Clip else TextOverflow.Ellipsis,
+                        onTextLayout = { result ->
+                            layoutResult = result
+                            if (!isExpanded) {
+                                hasOverflow = result.hasVisualOverflow
+                            }
+                        },
+                        modifier = Modifier.pointerInput(annotatedText, layoutResult) {
+                            detectTapGestures { tapOffset ->
+                                val result = layoutResult ?: return@detectTapGestures
+                                val offset = result.getOffsetForPosition(tapOffset)
+                                annotatedText
+                                    .getStringAnnotations(UrlAnnotationTag, offset, offset)
+                                    .firstOrNull()
+                                    ?.item
+                                    ?.let { url ->
+                                        if (onLinkClick != null) onLinkClick(url)
+                                        else uriHandler.openUri(url)
+                                    }
+                            }
+                        },
+                    )
+                }
             }
             if (!expanded && hasOverflow) {
                 Text(

--- a/app/src/main/java/com/yenaly/han1meviewer/ui/component/VideoCardItem.kt
+++ b/app/src/main/java/com/yenaly/han1meviewer/ui/component/VideoCardItem.kt
@@ -37,6 +37,7 @@ import com.yenaly.han1meviewer.logic.model.VideoItemType
 import com.yenaly.han1meviewer.ui.preview.ComponentPreview
 import com.yenaly.han1meviewer.ui.preview.fakeVideosItem
 import com.yenaly.han1meviewer.ui.screen.RetryableImage
+import com.yenaly.han1meviewer.util.DisplayTextLocalizer
 
 
 /**
@@ -141,7 +142,7 @@ fun VideoCardItem(
                         )
                         Text(
                             modifier = Modifier.padding(horizontal = 2.dp),
-                            text = it,
+                            text = DisplayTextLocalizer.localizeViews(it),
                             color = MaterialTheme.colorScheme.onSurface,
                             fontSize = textFontSize,
                         )
@@ -246,7 +247,7 @@ fun VideoCardItem(
                 Spacer(modifier = Modifier.weight(1f))
                 if (!videoItem.uploadTime.isNullOrEmpty()) {
                     Text(
-                        text = videoItem.uploadTime!!,
+                        text = DisplayTextLocalizer.localizeRelativeTime(videoItem.uploadTime!!),
                         fontSize = 11.sp,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,

--- a/app/src/main/java/com/yenaly/han1meviewer/ui/component/VideoCommentCard.kt
+++ b/app/src/main/java/com/yenaly/han1meviewer/ui/component/VideoCommentCard.kt
@@ -31,6 +31,7 @@ import coil3.compose.AsyncImage
 import com.yenaly.han1meviewer.R
 import com.yenaly.han1meviewer.logic.model.VideoComments
 import com.yenaly.han1meviewer.ui.preview.ComponentPreview
+import com.yenaly.han1meviewer.util.DisplayTextLocalizer
 
 /**
  * 视频评论卡片组件。
@@ -92,7 +93,7 @@ fun VideoCommentCard(
                         overflow = TextOverflow.Ellipsis,
                     )
                     Text(
-                        text = comment.date,
+                        text = DisplayTextLocalizer.localizeRelativeTime(comment.date),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )

--- a/app/src/main/java/com/yenaly/han1meviewer/ui/component/VideoCommentCard.kt
+++ b/app/src/main/java/com/yenaly/han1meviewer/ui/component/VideoCommentCard.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
@@ -102,17 +103,17 @@ fun VideoCommentCard(
                 IconButton(onClick = onReport, modifier = Modifier.size(36.dp)) {
                     Icon(
                         painter = painterResource(R.drawable.ic_baseline_report_24),
-                        contentDescription = stringResource(R.string.submit_bug),
+                        contentDescription = stringResource(R.string.report_reason_hint),
                         tint = MaterialTheme.colorScheme.primary
                     )
                 }
             }
-
-            Text(
-                text = comment.content,
-                style = MaterialTheme.typography.bodyMedium,
-            )
-
+            SelectionContainer {
+                Text(
+                    text = comment.content,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
             Row(
                 horizontalArrangement = Arrangement.spacedBy(4.dp),
                 verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/yenaly/han1meviewer/ui/screen/home/preview/PreviewInfoCard.kt
+++ b/app/src/main/java/com/yenaly/han1meviewer/ui/screen/home/preview/PreviewInfoCard.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.Button
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.MaterialTheme
@@ -77,23 +78,26 @@ fun PreviewInfoCard(
                             )
                         )
                 )
-                Column(
+                SelectionContainer(
                     modifier = Modifier
                         .align(Alignment.BottomStart)
                         .padding(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(6.dp),
                 ) {
-                    Text(
-                        text = previewInfo.videoTitle.orEmpty(),
-                        style = MaterialTheme.typography.titleLarge,
-                        fontWeight = FontWeight.Bold,
-                    )
-                    if (!previewInfo.title.isNullOrBlank()) {
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
                         Text(
-                            text = previewInfo.title,
-                            style = MaterialTheme.typography.titleMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            text = previewInfo.videoTitle.orEmpty(),
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.Bold,
                         )
+                        if (!previewInfo.title.isNullOrBlank()) {
+                            Text(
+                                text = previewInfo.title,
+                                style = MaterialTheme.typography.titleMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
                     }
                 }
             }
@@ -124,11 +128,13 @@ fun PreviewInfoCard(
                     }
                 }
                 if (!previewInfo.introduction.isNullOrBlank()) {
-                    Text(
-                        text = previewInfo.introduction,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+                    SelectionContainer {
+                        Text(
+                            text = previewInfo.introduction,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
                 }
 
                 if (previewInfo.tags.isNotEmpty()) {

--- a/app/src/main/java/com/yenaly/han1meviewer/ui/screen/video/VideoIntroductionScreen.kt
+++ b/app/src/main/java/com/yenaly/han1meviewer/ui/screen/video/VideoIntroductionScreen.kt
@@ -88,6 +88,7 @@ import com.yenaly.han1meviewer.ui.screen.rememberCardResponsiveWidth
 import com.yenaly.han1meviewer.ui.theme.SpacingNormal
 import com.yenaly.han1meviewer.ui.theme.VideoNormalCardMinWidth
 import com.yenaly.han1meviewer.ui.theme.VideoSimplifiedCardMinWidth
+import com.yenaly.han1meviewer.util.DisplayTextLocalizer
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.format
@@ -877,7 +878,7 @@ private fun MetaSection(video: HanimeVideo, fromDownload: Boolean) {
     val viewsText = if (fromDownload) {
         stringResource(R.string.s_view_times, "0721")
     } else {
-        stringResource(R.string.s_view_times, video.views.toString())
+        DisplayTextLocalizer.localizeViews(video.views.toString())
     }
     val uploadTime = video.uploadTime?.format(previewSafeDateFormat).orEmpty()
 

--- a/app/src/main/java/com/yenaly/han1meviewer/ui/screen/video/VideoIntroductionScreen.kt
+++ b/app/src/main/java/com/yenaly/han1meviewer/ui/screen/video/VideoIntroductionScreen.kt
@@ -1,5 +1,6 @@
 package com.yenaly.han1meviewer.ui.screen.video
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
@@ -31,6 +32,7 @@ import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
@@ -38,6 +40,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -808,14 +811,24 @@ private fun ArtistSection(
                 )
             }
             artist.post?.let {
-                Button(onClick = onToggleSubscribe) {
-                    Text(
-                        text = if (artist.isSubscribed) {
-                            stringResource(R.string.subscribed)
-                        } else {
-                            stringResource(R.string.subscribe)
-                        }
-                    )
+                if (artist.isSubscribed) {
+                    OutlinedButton(
+                        onClick = onToggleSubscribe,
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                            contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                        ),
+                        border = BorderStroke(
+                            width = 1.dp,
+                            color = MaterialTheme.colorScheme.outlineVariant
+                        )
+                    ) {
+                        Text(text = stringResource(R.string.subscribed))
+                    }
+                } else {
+                    Button(onClick = onToggleSubscribe) {
+                        Text(text = stringResource(R.string.subscribe))
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/yenaly/han1meviewer/ui/screen/video/VideoIntroductionScreen.kt
+++ b/app/src/main/java/com/yenaly/han1meviewer/ui/screen/video/VideoIntroductionScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -842,26 +843,31 @@ private fun TitleSection(video: HanimeVideo, onCopyText: (String) -> Unit) {
     val secondaryTitle = video.title.takeIf { it != primaryTitle }
 
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-        Text(
-            text = primaryTitle,
-            style = MaterialTheme.typography.headlineSmall,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.combinedClickable(
-                onClick = {},
-                onLongClick = { onCopyText(primaryTitle) },
-            )
-        )
-        secondaryTitle?.let {
+        SelectionContainer {
             Text(
-                text = it,
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                text = primaryTitle,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier.combinedClickable(
                     onClick = {},
-                    onLongClick = { onCopyText(it) },
+                    onLongClick = { },
                 )
             )
+        }
+
+        secondaryTitle?.let {
+            SelectionContainer {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.combinedClickable(
+                        onClick = {},
+                        onLongClick = { },
+                    )
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/yenaly/han1meviewer/ui/screen/video/VideoTabScreens.kt
+++ b/app/src/main/java/com/yenaly/han1meviewer/ui/screen/video/VideoTabScreens.kt
@@ -76,7 +76,9 @@ fun RenderVideoIntroductionContent(
             onRetry = { viewModel.getHanimeVideo(videoCode) },
             onOpenVideo = onOpenVideo,
             onOpenArtist = onOpenArtist,
-            onNavigateToSearch = onNavigateToSearch,
+            onNavigateToSearch = { tag ->
+                onNavigateToSearch(viewModel.resolveTagSearchKey(tag))
+            },
             onToggleSubscribe = onToggleSubscribe,
             onToggleFavorite = { video?.let(onToggleFavorite) },
             onManageMyList = { _, selectedStates ->

--- a/app/src/main/java/com/yenaly/han1meviewer/ui/viewmodel/PreviewViewModel.kt
+++ b/app/src/main/java/com/yenaly/han1meviewer/ui/viewmodel/PreviewViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.yenaly.han1meviewer.logic.NetworkRepo
 import com.yenaly.han1meviewer.logic.model.HanimePreview
 import com.yenaly.han1meviewer.logic.state.WebsiteState
+import com.yenaly.han1meviewer.util.TagLocalizer
 import com.yenaly.yenaly_libs.base.YenalyViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -34,9 +35,10 @@ class PreviewViewModel(application: Application) : YenalyViewModel(application) 
                 return@launch
             }
             NetworkRepo.getHanimePreview(date).collect { preview ->
-                _previewFlow.value = preview
-                if (preview !is WebsiteState.Loading) {
-                    previewCache[date] = preview
+                val localizedPreview = preview.withLocalizedTags()
+                _previewFlow.value = localizedPreview
+                if (localizedPreview !is WebsiteState.Loading) {
+                    previewCache[date] = localizedPreview
                 }
             }
         }
@@ -52,9 +54,23 @@ class PreviewViewModel(application: Application) : YenalyViewModel(application) 
                         .first { it !is WebsiteState.Loading }
                 }
             }.getOrElse { WebsiteState.Error(it) }
-            previewCache[date] = preview
+            previewCache[date] = preview.withLocalizedTags()
         }
     }
 
     fun getCachedPreview(date: String): WebsiteState<HanimePreview>? = previewCache[date]
+
+    private fun WebsiteState<HanimePreview>.withLocalizedTags(): WebsiteState<HanimePreview> {
+        return if (this is WebsiteState.Success) {
+            WebsiteState.Success(info.withLocalizedTags())
+        } else {
+            this
+        }
+    }
+
+    private fun HanimePreview.withLocalizedTags(): HanimePreview {
+        return copy(previewInfo = previewInfo.map { info ->
+            info.copy(tags = TagLocalizer.localizeTags(info.tags))
+        })
+    }
 }

--- a/app/src/main/java/com/yenaly/han1meviewer/ui/viewmodel/VideoViewModel.kt
+++ b/app/src/main/java/com/yenaly/han1meviewer/ui/viewmodel/VideoViewModel.kt
@@ -23,6 +23,7 @@ import com.yenaly.han1meviewer.logic.model.HanimeVideo
 import com.yenaly.han1meviewer.logic.state.VideoLoadingState
 import com.yenaly.han1meviewer.logic.state.WebsiteState
 import com.yenaly.han1meviewer.ui.viewmodel.AppViewModel.csrfToken
+import com.yenaly.han1meviewer.util.TagLocalizer
 import com.yenaly.yenaly_libs.base.YenalyViewModel
 import com.yenaly.yenaly_libs.utils.dp
 import kotlinx.coroutines.Dispatchers
@@ -189,6 +190,13 @@ class VideoViewModel(application: Application) : YenalyViewModel(application) {
         videoIntroUiStateMap[videoCode] = current.transform()
     }
 
+    fun resolveTagSearchKey(tag: String): String = TagLocalizer.resolveSearchKey(tag)
+
+    private fun HanimeVideo.withLocalizedTags(): HanimeVideo {
+        if (tags.isEmpty()) return this
+        return copy(tags = TagLocalizer.localizeTags(tags))
+    }
+
     fun buildLocalPlayInfo(localPath: String? = null): HanimeVideo {
         val resolution = HanimeResolution()
         resolution.parseResolution(
@@ -209,10 +217,9 @@ class VideoViewModel(application: Application) : YenalyViewModel(application) {
     }
     fun getHanimeVideo(videoCode: String,localUri: String? = null) {
         if (videoCode == "-1"){
-            _hanimeVideoStateFlow.value = VideoLoadingState.Success(
-                buildLocalPlayInfo(localUri)
-            )
-            _hanimeVideoFlow.value = buildLocalPlayInfo(localUri)
+            val localPlayInfo = buildLocalPlayInfo(localUri)
+            _hanimeVideoStateFlow.value = VideoLoadingState.Success(localPlayInfo)
+            _hanimeVideoFlow.value = localPlayInfo
             return
         }
         if (videoIntroUiStateMap[videoCode]?.introRestored == true) return
@@ -229,16 +236,25 @@ class VideoViewModel(application: Application) : YenalyViewModel(application) {
                 NetworkRepo.getHanimeVideo(videoCode)
             }
             flow.collect { state ->
-                val emitState = if (localUri != null && state is VideoLoadingState.Success) {
-                    val resolution = HanimeResolution()
-                    resolution.parseResolution(
-                        HanimeResolution.RES_1080P,
-                        resLink = localUri,
-                        type = "video/mp4"
-                    )
-                    VideoLoadingState.Success(state.info.copy(videoUrls = resolution.toResolutionLinkMap()))
-                } else {
-                    state
+                val emitState = when {
+                    localUri != null && state is VideoLoadingState.Success -> {
+                        val resolution = HanimeResolution()
+                        resolution.parseResolution(
+                            HanimeResolution.RES_1080P,
+                            resLink = localUri,
+                            type = "video/mp4"
+                        )
+                        VideoLoadingState.Success(
+                            state.info.copy(videoUrls = resolution.toResolutionLinkMap())
+                                .withLocalizedTags()
+                        )
+                    }
+
+                    state is VideoLoadingState.Success -> {
+                        VideoLoadingState.Success(state.info.withLocalizedTags())
+                    }
+
+                    else -> state
                 }
                 _hanimeVideoStateFlow.value = emitState
                 if (emitState is VideoLoadingState.Success) {
@@ -250,7 +266,7 @@ class VideoViewModel(application: Application) : YenalyViewModel(application) {
     }
 
     fun restoreFromCacheIfExists(code: String): Boolean {
-        val cached = videoIntroUiStateMap[code]?.cachedVideo ?: return false
+        val cached = videoIntroUiStateMap[code]?.cachedVideo?.withLocalizedTags() ?: return false
         updateVideoIntroUiState(code) { copy(introRestored = true) }
         _hanimeVideoFlow.value = cached
         _hanimeVideoStateFlow.value = VideoLoadingState.Success(cached)

--- a/app/src/main/java/com/yenaly/han1meviewer/ui/viewmodel/VideoViewModel.kt
+++ b/app/src/main/java/com/yenaly/han1meviewer/ui/viewmodel/VideoViewModel.kt
@@ -192,9 +192,11 @@ class VideoViewModel(application: Application) : YenalyViewModel(application) {
 
     fun resolveTagSearchKey(tag: String): String = TagLocalizer.resolveSearchKey(tag)
 
-    private fun HanimeVideo.withLocalizedTags(): HanimeVideo {
-        if (tags.isEmpty()) return this
-        return copy(tags = TagLocalizer.localizeTags(tags))
+    private fun HanimeVideo.withLocalizedLabels(): HanimeVideo {
+        return copy(
+            tags = TagLocalizer.localizeTags(tags),
+            artist = artist?.copy(genre = TagLocalizer.localizeTag(artist.genre)),
+        )
     }
 
     fun buildLocalPlayInfo(localPath: String? = null): HanimeVideo {
@@ -246,12 +248,12 @@ class VideoViewModel(application: Application) : YenalyViewModel(application) {
                         )
                         VideoLoadingState.Success(
                             state.info.copy(videoUrls = resolution.toResolutionLinkMap())
-                                .withLocalizedTags()
+                                .withLocalizedLabels()
                         )
                     }
 
                     state is VideoLoadingState.Success -> {
-                        VideoLoadingState.Success(state.info.withLocalizedTags())
+                        VideoLoadingState.Success(state.info.withLocalizedLabels())
                     }
 
                     else -> state
@@ -266,7 +268,7 @@ class VideoViewModel(application: Application) : YenalyViewModel(application) {
     }
 
     fun restoreFromCacheIfExists(code: String): Boolean {
-        val cached = videoIntroUiStateMap[code]?.cachedVideo?.withLocalizedTags() ?: return false
+        val cached = videoIntroUiStateMap[code]?.cachedVideo?.withLocalizedLabels() ?: return false
         updateVideoIntroUiState(code) { copy(introRestored = true) }
         _hanimeVideoFlow.value = cached
         _hanimeVideoStateFlow.value = VideoLoadingState.Success(cached)

--- a/app/src/main/java/com/yenaly/han1meviewer/util/DisplayTextLocalizer.kt
+++ b/app/src/main/java/com/yenaly/han1meviewer/util/DisplayTextLocalizer.kt
@@ -1,0 +1,97 @@
+package com.yenaly.han1meviewer.util
+
+import com.yenaly.yenaly_libs.utils.LanguageHelper
+import java.math.BigDecimal
+import java.util.Locale
+
+object DisplayTextLocalizer {
+
+    private val viewsRegex = Regex("^(.+?)(万次|萬次|次)$")
+    private val relativeTimeRegex = Regex("^(?:ge)?(.+?)(分钟|分鐘|小时|小時|天|周|週|个月|個月|年)前$")
+
+    fun localizeViews(text: String): String {
+        val match = viewsRegex.matchEntire(text.trim()) ?: return text
+        val count = match.groupValues[1]
+        val unit = match.groupValues[2]
+        return when (language()) {
+            Locale.SIMPLIFIED_CHINESE.language -> when (unit) {
+                "万次", "萬次" -> "${count}万次"
+                else -> "${count}次"
+            }
+
+            Locale.ENGLISH.language -> when (unit) {
+                "万次", "萬次" -> "${count.toKViews()} views"
+                else -> "$count views"
+            }
+
+            Locale.JAPANESE.language -> when (unit) {
+                "万次", "萬次" -> "${count}万回"
+                else -> "${count}回"
+            }
+
+            else -> when (unit) {
+                "万次", "萬次" -> "${count}萬次"
+                else -> "${count}次"
+            }
+        }
+    }
+
+    fun localizeRelativeTime(text: String): String {
+        val match = relativeTimeRegex.matchEntire(text.trim()) ?: return text
+        val count = match.groupValues[1]
+        val unit = match.groupValues[2]
+        return when (language()) {
+            Locale.SIMPLIFIED_CHINESE.language -> "$count${unit.toSimplifiedUnit()}前"
+            Locale.ENGLISH.language -> "$count ${unit.toEnglishUnit(count)} ago"
+            Locale.JAPANESE.language -> "$count${unit.toJapaneseUnit()}前"
+            else -> "$count${unit.toTraditionalUnit()}前"
+        }
+    }
+
+    private fun language(): String = LanguageHelper.preferredLanguage.language
+
+    private fun String.toSimplifiedUnit(): String = when (this) {
+        "分鐘", "分钟" -> "分钟"
+        "小時", "小时" -> "小时"
+        "週", "周" -> "周"
+        "個月", "个月" -> "个月"
+        else -> this
+    }
+
+    private fun String.toTraditionalUnit(): String = when (this) {
+        "分钟", "分鐘" -> "分鐘"
+        "小时", "小時" -> "小時"
+        "周", "週" -> "週"
+        "个月", "個月" -> "個月"
+        else -> this
+    }
+
+    private fun String.toJapaneseUnit(): String = when (this) {
+        "分钟", "分鐘" -> "分"
+        "小时", "小時" -> "時間"
+        "天" -> "日"
+        "周", "週" -> "週間"
+        "个月", "個月" -> "か月"
+        "年" -> "年"
+        else -> this
+    }
+
+    private fun String.toEnglishUnit(count: String): String {
+        val singular = count == "1"
+        return when (this) {
+            "分钟", "分鐘" -> if (singular) "minute" else "minutes"
+            "小时", "小時" -> if (singular) "hour" else "hours"
+            "天" -> if (singular) "day" else "days"
+            "周", "週" -> if (singular) "week" else "weeks"
+            "个月", "個月" -> if (singular) "month" else "months"
+            "年" -> if (singular) "year" else "years"
+            else -> this
+        }
+    }
+
+    private fun String.toKViews(): String {
+        return runCatching {
+            BigDecimal(this).multiply(BigDecimal.TEN).stripTrailingZeros().toPlainString() + "K"
+        }.getOrElse { "${this}0K" }
+    }
+}

--- a/app/src/main/java/com/yenaly/han1meviewer/util/TagLocalizer.kt
+++ b/app/src/main/java/com/yenaly/han1meviewer/util/TagLocalizer.kt
@@ -20,8 +20,10 @@ object TagLocalizer {
 
     fun localizeTags(tags: List<String>): List<String> {
         if (tags.isEmpty()) return tags
-        return tags.map { tag -> tagMappings.labels[tag] ?: tag }
+        return tags.map(::localizeTag)
     }
+
+    fun localizeTag(tag: String): String = tagMappings.labels[tag] ?: tag
 
     fun resolveSearchKey(tag: String): String = tagMappings.searchKeys[tag] ?: tag
 

--- a/app/src/main/java/com/yenaly/han1meviewer/util/TagLocalizer.kt
+++ b/app/src/main/java/com/yenaly/han1meviewer/util/TagLocalizer.kt
@@ -1,6 +1,7 @@
 package com.yenaly.han1meviewer.util
 
 import com.yenaly.han1meviewer.logic.model.SearchOption
+import com.yenaly.yenaly_libs.utils.LanguageHelper
 
 object TagLocalizer {
 
@@ -9,14 +10,26 @@ object TagLocalizer {
         val searchKeys: Map<String, String>,
     )
 
-    private val tagMappings: TagMappings by lazy {
-        buildTagMappings(
-            loadAssetAs<Map<String, List<SearchOption>>>("search_options/tags.json")
-                .orEmpty()
-                .values
-                .flatten() + loadAssetAs<List<SearchOption>>("search_options/genre.json").orEmpty()
-        )
+    private val tagOptions: List<SearchOption> by lazy {
+        loadAssetAs<Map<String, List<SearchOption>>>("search_options/tags.json")
+            .orEmpty()
+            .values
+            .flatten() + loadAssetAs<List<SearchOption>>("search_options/genre.json").orEmpty()
     }
+
+    private var cachedLanguageTag: String? = null
+    private var cachedMappings: TagMappings? = null
+
+    private val tagMappings: TagMappings
+        get() {
+            val languageTag = LanguageHelper.preferredLanguage.toLanguageTag()
+            val mappings = cachedMappings
+            if (cachedLanguageTag == languageTag && mappings != null) return mappings
+            return buildTagMappings(tagOptions).also {
+                cachedLanguageTag = languageTag
+                cachedMappings = it
+            }
+        }
 
     fun localizeTags(tags: List<String>): List<String> {
         if (tags.isEmpty()) return tags

--- a/app/src/main/java/com/yenaly/han1meviewer/util/TagLocalizer.kt
+++ b/app/src/main/java/com/yenaly/han1meviewer/util/TagLocalizer.kt
@@ -1,0 +1,48 @@
+package com.yenaly.han1meviewer.util
+
+import com.yenaly.han1meviewer.logic.model.SearchOption
+
+object TagLocalizer {
+
+    private data class TagMappings(
+        val labels: Map<String, String>,
+        val searchKeys: Map<String, String>,
+    )
+
+    private val tagMappings: TagMappings by lazy {
+        buildTagMappings(
+            loadAssetAs<Map<String, List<SearchOption>>>("search_options/tags.json")
+                .orEmpty()
+                .values
+                .flatten() + loadAssetAs<List<SearchOption>>("search_options/genre.json").orEmpty()
+        )
+    }
+
+    fun localizeTags(tags: List<String>): List<String> {
+        if (tags.isEmpty()) return tags
+        return tags.map { tag -> tagMappings.labels[tag] ?: tag }
+    }
+
+    fun resolveSearchKey(tag: String): String = tagMappings.searchKeys[tag] ?: tag
+
+    private fun buildTagMappings(options: List<SearchOption>): TagMappings {
+        val labels = mutableMapOf<String, String>()
+        val searchKeys = mutableMapOf<String, String>()
+        options.forEach { option ->
+            val label = option.value.takeIf { it.isNotBlank() } ?: return@forEach
+            val searchKey = option.searchKey?.takeIf { it.isNotBlank() } ?: return@forEach
+            listOfNotNull(
+                option.searchKey,
+                option.name,
+                option.lang?.zhrCN,
+                option.lang?.zhrTW,
+                option.lang?.en,
+                option.lang?.ja,
+            ).forEach { rawTag ->
+                labels.putIfAbsent(rawTag, label)
+                searchKeys.putIfAbsent(rawTag, searchKey)
+            }
+        }
+        return TagMappings(labels = labels, searchKeys = searchKeys)
+    }
+}


### PR DESCRIPTION
### 新增 (Added)
- 为关注按钮的不同状态提供颜色区分 (#395)
- 增加标签、排序方式、举报原因的日文翻译
- 添加部分视频元数据的多语言映射 (#395)
- 影片描述和影片标题允许选择复制
- 评论允许选择复制

### 优化 (Improved)
- 对齐网站 tag
- 增加详情页、新番预览页的 tag 语言映射 (#395)

### 移除 (Removed)
- 取消标题的长按复制功能，防止污染剪贴板